### PR TITLE
averaging kf2kf preint time to per f2f

### DIFF
--- a/include/Frame.h
+++ b/include/Frame.h
@@ -201,7 +201,6 @@ public:
   std::vector<cv::KeyPoint> mvKeys;
   std::vector<cv::KeyPoint> mvKeysUn;
   std::vector<std::vector<cv::KeyPoint>> vvkeys_ = std::vector<std::vector<cv::KeyPoint>>(1);
-  std::vector<std::vector<cv::KeyPoint>> vvkeys_un_;
   std::vector<std::vector<size_t>> mapin2n_; // mapcamidx2n_ for addobs func.
 
   // Corresponding stereo coordinate and depth for each keypoint.

--- a/include/Frame.h
+++ b/include/Frame.h
@@ -1,30 +1,30 @@
 /**
-* This file is part of ORB-SLAM2.
-*
-* Copyright (C) 2014-2016 Raúl Mur-Artal <raulmur at unizar dot es> (University of Zaragoza)
-* For more information see <https://github.com/leavesnight/VIEO_SLAM>
-*
-* ORB-SLAM2 is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* ORB-SLAM2 is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
-*/
+ * This file is part of ORB-SLAM2.
+ *
+ * Copyright (C) 2014-2016 Raúl Mur-Artal <raulmur at unizar dot es> (University of Zaragoza)
+ * For more information see <https://github.com/leavesnight/VIEO_SLAM>
+ *
+ * ORB-SLAM2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ORB-SLAM2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef FRAME_H
 #define FRAME_H
 
-#include "OdomPreIntegrator.h"//zzh
+#include "OdomPreIntegrator.h"  //zzh
 #include "NavState.h"
 
-#include<vector>
+#include <vector>
 
 #include "FrameBase.h"
 #include "MapPoint.h"
@@ -35,8 +35,7 @@
 
 #include <opencv2/opencv.hpp>
 
-namespace VIEO_SLAM
-{
+namespace VIEO_SLAM {
 #define FRAME_GRID_ROWS 48
 #define FRAME_GRID_COLS 64
 
@@ -44,156 +43,165 @@ class KeyFrame;
 class MapPoint;
 class GeometricCamera;
 
-class Frame : public FrameBase
-{ 
-public:
-  //const Tbc,Tce, so it can be used in multi threads
-  static cv::Mat mTbc,mTce;
-  static Eigen::Matrix3d meigRcb;static Eigen::Vector3d meigtcb;
-  
+class Frame : public FrameBase {
+ public:
+  // const Tbc,Tce, so it can be used in multi threads
+  static cv::Mat mTbc, mTce;
+  static Eigen::Matrix3d meigRcb;
+  static Eigen::Vector3d meigtcb;
+
   // Odom PreIntegration, j means this frame, i means last frame(not KF), if no measurements it will be cv::Mat()
   EncPreIntegrator mOdomPreIntEnc;
   IMUPreintegrator mOdomPreIntIMU;
   // state xi={Ri,pi,vi,bi}, not designed for multi threads/just used in Tracking thread
   NavState mNavState;
   // For pose optimization/motion-only BA, use as prior and prior information(inverse covariance)
-  Matrix<double,15,15> mMargCovInv;//Sigmap in VIORBSLAM paper/prior Hessian matrix for next Frame, notice it's unintialized(to infinity/fixedlast)
-  NavState mNavStatePrior;//needed by PoseOptimization twice, notice if no imu data, it's unintialized
-  bool mbPrior;//meaning if mNavStatePrior&mMargCovInv exist
-  
-  const NavState& GetNavState(void){//cannot use const &(make mutex useless)
-    return mNavState;//don't call copy constructor, just for template of PoseOptimization() & PreIntegration
+  Matrix<double, 15, 15> mMargCovInv;  // Sigmap in VIORBSLAM paper/prior Hessian matrix for next Frame, notice it's
+                                       // unintialized(to infinity/fixedlast)
+  NavState mNavStatePrior;  // needed by PoseOptimization twice, notice if no imu data, it's unintialized
+  bool mbPrior;             // meaning if mNavStatePrior&mMargCovInv exist
+
+  const NavState &GetNavState(void) {  // cannot use const &(make mutex useless)
+    return mNavState;  // don't call copy constructor, just for template of PoseOptimization() & PreIntegration
   }
-  void UpdatePoseFromNS();//replace SetPose(), directly update mNavState for efficiency and then please call this func. to update Tcw
-  void UpdateNavStatePVRFromTcw();//for imu data empty condition after imu's initialized(including bias recomputed)
-  
+  void UpdatePoseFromNS();  // replace SetPose(), directly update mNavState for efficiency and then please call this
+                            // func. to update Tcw
+  void UpdateNavStatePVRFromTcw();  // for imu data empty condition after imu's initialized(including bias recomputed)
+
   // Odom PreIntegration
-//   template <class _OdomData>
-//   void SetPreIntegrationList(const typename std::list<_OdomData>::const_iterator &begin,const typename std::>::const_iterator &pback){//notice template definition should be written in the same file! & typename should be added before nested type!
-//     mOdomPreIntEnc.SetPreIntegrationList(begin,pback);
-//   }
-  template <class _OdomData>//here if u use _Frame*, it can be automatically checked while vector<_Frame>::iterator won't do so! but partial specialized template function doesn't exist!
-  void PreIntegration(Frame* pLastF,const typename listeig(_OdomData)::const_iterator &iteri,
-		      typename listeig(_OdomData)::const_iterator iterjBack){//0th frame don't use this function
-    mOdomPreIntEnc.PreIntegration(pLastF->mTimeStamp,mTimeStamp,iteri,++iterjBack);//here need ++!
+  //   template <class _OdomData>
+  //   void SetPreIntegrationList(const typename std::list<_OdomData>::const_iterator &begin,const typename
+  //   std::>::const_iterator &pback){//notice template definition should be written in the same file! & typename should
+  //   be added before nested type!
+  //     mOdomPreIntEnc.SetPreIntegrationList(begin,pback);
+  //   }
+  template <class _OdomData>  // here if u use _Frame*, it can be automatically checked while vector<_Frame>::iterator
+                              // won't do so! but partial specialized template function doesn't exist!
+                              void PreIntegration(Frame *pLastF,
+                                                  const typename listeig(_OdomData)::const_iterator &iteri,
+                                                  typename listeig(_OdomData)::const_iterator
+                                                      iterjBack) {  // 0th frame don't use this function
+    mOdomPreIntEnc.PreIntegration(pLastF->mTimeStamp, mTimeStamp, iteri, ++iterjBack);  // here need ++!
   }
   template <class _OdomData>
-  void PreIntegration(KeyFrame* pLastKF,const typename listeig(_OdomData)::const_iterator &iteri,
-		      typename listeig(_OdomData)::const_iterator iterjBack);//0th frame don't use this function, just declare and we only use specialized 2 versions for KeyFrame cannot be directly used in this head file
-  
-  //for LoadMap() in System.cc
-  Frame(istream &is,ORBVocabulary* voc);
-  bool read(istream &is,bool bOdomList=false);//we use Frame::read(is,false) before KeyFrame's constructor
-  bool write(ostream &os) const;//though we don't save Frame
-  
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW//for quaterniond in NavState && Matrix4d
-//created by zzh over.
-  
-public:
-    Frame();
+  void PreIntegration(KeyFrame *pLastKF, const typename listeig(_OdomData)::const_iterator &iteri,
+                      typename listeig(_OdomData)::const_iterator
+                          iterjBack);  // 0th frame don't use this function, just declare and we only use specialized 2
+                                       // versions for KeyFrame cannot be directly used in this head file
 
-    // Copy constructor. use default = func. is the mGrid[A][B] copy OK?
-    Frame(const Frame &frame);
+  // for LoadMap() in System.cc
+  Frame(istream &is, ORBVocabulary *voc);
+  bool read(istream &is, bool bOdomList = false);  // we use Frame::read(is,false) before KeyFrame's constructor
+  bool write(ostream &os) const;                   // though we don't save Frame
 
-    // Constructor for stereo cameras.
-    Frame(const vector<cv::Mat> &ims, const double &timeStamp, vector<ORBextractor*> extractors, ORBVocabulary* voc, cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth, const vector<GeometricCamera*> *pCamInsts = nullptr, bool usedistort = true);
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW  // for quaterniond in NavState && Matrix4d
+  // created by zzh over.
+  Frame();
 
-    // Constructor for RGB-D cameras.
-    Frame(const cv::Mat &imGray, const cv::Mat &imDepth, const double &timeStamp, ORBextractor* extractor,ORBVocabulary* voc, cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth);
+  // Copy constructor. use default = func. is the mGrid[A][B] copy OK?
+  Frame(const Frame &frame);
 
-    // Constructor for Monocular cameras.
-    Frame(const cv::Mat &imGray, const double &timeStamp, ORBextractor* extractor,ORBVocabulary* voc, cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth);
+  // Constructor for stereo cameras.
+  Frame(const vector<cv::Mat> &ims, const double &timeStamp, vector<ORBextractor *> extractors, ORBVocabulary *voc,
+        cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth,
+        const vector<GeometricCamera *> *pCamInsts = nullptr, bool usedistort = true);
 
-    std::vector<MapPoint*> &GetMapPointsRef() { return mvpMapPoints; }
+  // Constructor for RGB-D cameras.
+  Frame(const cv::Mat &imGray, const cv::Mat &imDepth, const double &timeStamp, ORBextractor *extractor,
+        ORBVocabulary *voc, cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth);
 
-    // Extract ORB on the image. 0 for left image and 1 for right image.
-    void ExtractORB(int flag, const cv::Mat &im, std::vector<int> *pvLappingArea = nullptr);
+  // Constructor for Monocular cameras.
+  Frame(const cv::Mat &imGray, const double &timeStamp, ORBextractor *extractor, ORBVocabulary *voc, cv::Mat &K,
+        cv::Mat &distCoef, const float &bf, const float &thDepth);
 
-    // Compute Bag of Words representation.
-    void ComputeBoW();//compute mBowVec && mFeatVec
+  std::vector<MapPoint *> &GetMapPointsRef() { return mvpMapPoints; }
 
-    // Set the camera pose.
-    void SetPose(cv::Mat Tcw);
+  // Extract ORB on the image. 0 for left image and 1 for right image.
+  void ExtractORB(int flag, const cv::Mat &im, std::vector<int> *pvLappingArea = nullptr);
 
-    // Computes rotation, translation and camera center matrices from the camera pose.
-    void UpdatePoseMatrices();
+  // Compute Bag of Words representation.
+  void ComputeBoW();  // compute mBowVec && mFeatVec
 
-    // Returns the camera center.
-    inline cv::Mat GetCameraCenter(){
-        return mOw.clone();
-    }
+  // Set the camera pose.
+  void SetPose(cv::Mat Tcw);
 
-    // Returns inverse of rotation
-    inline cv::Mat GetRotationInverse(){
-        return mRwc.clone();
-    }
+  // Computes rotation, translation and camera center matrices from the camera pose.
+  void UpdatePoseMatrices();
 
-    // Check if a MapPoint is in the frustum of the camera
-    // and fill variables of the MapPoint to be used by the tracking
-    bool isInFrustum(MapPoint* pMP, float viewingCosLimit);
+  // Returns the camera center.
+  inline cv::Mat GetCameraCenter() { return mOw.clone(); }
 
-    // Compute the cell of a keypoint (return false if outside the grid)
-    bool PosInGrid(const cv::KeyPoint &kp, int &posX, int &posY);
+  // Returns inverse of rotation
+  inline cv::Mat GetRotationInverse() { return mRwc.clone(); }
 
-    vector<size_t> GetFeaturesInArea(size_t cami, const float &x, const float  &y, const float  &r, const int minLevel=-1, const int maxLevel=-1) const;
+  // Check if a MapPoint is in the frustum of the camera
+  // and fill variables of the MapPoint to be used by the tracking
+  bool isInFrustum(MapPoint *pMP, float viewingCosLimit);
 
-    // Search a match for each keypoint in the left image to a keypoint in the right image.
-    // If there is a match, depth is computed and the right coordinate associated to the left keypoint is stored.
-    void ComputeStereoMatches();
+  // Compute the cell of a keypoint (return false if outside the grid)
+  bool PosInGrid(const cv::KeyPoint &kp, int &posX, int &posY);
 
-    void ComputeStereoFishEyeMatches();
+  vector<size_t> GetFeaturesInArea(size_t cami, const float &x, const float &y, const float &r, const int minLevel = -1,
+                                   const int maxLevel = -1) const;
 
-    // Associate a "right" coordinate to a keypoint if there is valid depth in the depthmap.
-    void ComputeStereoFromRGBD(const cv::Mat &imDepth);
+  // Search a match for each keypoint in the left image to a keypoint in the right image.
+  // If there is a match, depth is computed and the right coordinate associated to the left keypoint is stored.
+  void ComputeStereoMatches();
 
-    // Backprojects a keypoint (if stereo/depth info available) into 3D world coordinates.
-    cv::Mat UnprojectStereo(const int &i);
+  void ComputeStereoFishEyeMatches();
 
-public:
-    // Vocabulary used for relocalization.
-    ORBVocabulary* mpORBvocabulary;
+  // Associate a "right" coordinate to a keypoint if there is valid depth in the depthmap.
+  void ComputeStereoFromRGBD(const cv::Mat &imDepth);
 
-    // Feature extractor. The right is used only in the stereo case.
-    vector<ORBextractor*> mpORBextractors;
+  // Backprojects a keypoint (if stereo/depth info available) into 3D world coordinates.
+  cv::Mat UnprojectStereo(const int &i);
 
-    // Frame timestamp.
-    double mTimeStamp;
+ public:
+  // Vocabulary used for relocalization.
+  ORBVocabulary *mpORBvocabulary;
 
-    // Calibration matrix and OpenCV distortion parameters.
-    cv::Mat mK;
-    static float fx;
-    static float fy;
-    static float cx;
-    static float cy;
-    static float invfx;
-    static float invfy;
-    cv::Mat mDistCoef;
+  // Feature extractor. The right is used only in the stereo case.
+  vector<ORBextractor *> mpORBextractors;
 
-    // Stereo baseline multiplied by fx.
-    float mbf;
+  // Frame timestamp.
+  double mTimeStamp;
 
-    // Stereo baseline in meters.
-    float mb;
+  // Calibration matrix and OpenCV distortion parameters.
+  cv::Mat mK;
+  static float fx;
+  static float fy;
+  static float cx;
+  static float cy;
+  static float invfx;
+  static float invfy;
+  cv::Mat mDistCoef;
 
-    // Threshold close/far points. Close points are inserted from 1 view.
-    // Far points are inserted as in the monocular case from 2 views.
-    float mThDepth;
+  // Stereo baseline multiplied by fx.
+  float mbf;
 
-    // Number of KeyPoints.
-    int N;
-    //Number of Non Lapping Keypoints
-    vector<size_t> num_mono = vector<size_t>(1);
-    //For stereo matching
+  // Stereo baseline in meters.
+  float mb;
+
+  // Threshold close/far points. Close points are inserted from 1 view.
+  // Far points are inserted as in the monocular case from 2 views.
+  float mThDepth;
+
+  // Number of KeyPoints.
+  int N;
+  // Number of Non Lapping Keypoints
+  vector<size_t> num_mono = vector<size_t>(1);
+  // For stereo matching
   vector<vector<size_t>> mvidxsMatches;
-  vector<bool> goodmatches_; // keep same size with mvidxsMatches
-  map<pair<size_t, size_t>, size_t> mapcamidx2idxs_; // final size_t max < mvidxsMatches.size()
+  vector<bool> goodmatches_;                          // keep same size with mvidxsMatches
+  map<pair<size_t, size_t>, size_t> mapcamidx2idxs_;  // final size_t max < mvidxsMatches.size()
   size_t GetMapn2idxs(size_t i);
   vector<size_t> mapidxs2n_;
-    //For stereo fisheye matching
-    static cv::BFMatcher BFmatcher;
-    //Triangulated stereo observations using as reference the left camera. These are
-    //computed during ComputeStereoFishEyeMatches
-    aligned_vector<Vector3d> mv3Dpoints; // keep same size with mvidxsMatches
+  // For stereo fisheye matching
+  static cv::BFMatcher BFmatcher;
+  // Triangulated stereo observations using as reference the left camera. These are
+  // computed during ComputeStereoFishEyeMatches
+  aligned_vector<Vector3d> mv3Dpoints;  // keep same size with mvidxsMatches
 
   // Vector of keypoints (original for visualization) and undistorted (actually used by the system).
   // In the stereo case, mvKeysUn is redundant as images must be rectified.
@@ -201,7 +209,7 @@ public:
   std::vector<cv::KeyPoint> mvKeys;
   std::vector<cv::KeyPoint> mvKeysUn;
   std::vector<std::vector<cv::KeyPoint>> vvkeys_ = std::vector<std::vector<cv::KeyPoint>>(1);
-  std::vector<std::vector<size_t>> mapin2n_; // mapcamidx2n_ for addobs func.
+  std::vector<std::vector<size_t>> mapin2n_;  // mapcamidx2n_ for addobs func.
 
   // Corresponding stereo coordinate and depth for each keypoint.
   // "Monocular" keypoints have a negative value.
@@ -209,81 +217,84 @@ public:
   std::vector<float> mvDepth;
 
   // Bag of Words Vector structures.
-    DBoW2::BowVector mBowVec;
-    DBoW2::FeatureVector mFeatVec;
+  DBoW2::BowVector mBowVec;
+  DBoW2::FeatureVector mFeatVec;
 
-    // ORB descriptor, each row associated to a keypoint.
-    cv::Mat mDescriptors;
-    std::vector<cv::Mat> vdescriptors_ = std::vector<cv::Mat>(1);
+  // ORB descriptor, each row associated to a keypoint.
+  cv::Mat mDescriptors;
+  std::vector<cv::Mat> vdescriptors_ = std::vector<cv::Mat>(1);
 
-    // Flag to identify outlier associations.
-    std::vector<bool> mvbOutlier;
+  // Flag to identify outlier associations.
+  std::vector<bool> mvbOutlier;
 
-    // Keypoints are assigned to cells in a grid to reduce matching complexity when projecting MapPoints.
-    static float mfGridElementWidthInv;
-    static float mfGridElementHeightInv;
-    std::vector<std::vector<std::vector<std::vector<std::size_t>>>> vgrids_;
+  // Keypoints are assigned to cells in a grid to reduce matching complexity when projecting MapPoints.
+  static float mfGridElementWidthInv;
+  static float mfGridElementHeightInv;
+  std::vector<std::vector<std::vector<std::vector<std::size_t>>>> vgrids_;
 
-    // Current and Next Frame id.
-    static long unsigned int nNextId;
-    long unsigned int mnId;
+  // Current and Next Frame id.
+  static long unsigned int nNextId;
+  long unsigned int mnId;
 
-    // Reference Keyframe.
-    KeyFrame* mpReferenceKF;
+  // Reference Keyframe.
+  KeyFrame *mpReferenceKF;
 
-    // Scale pyramid info.
-    int mnScaleLevels;
-    float mfScaleFactor;
-    float mfLogScaleFactor;
-    vector<float> mvScaleFactors;
-    vector<float> mvInvScaleFactors;
-    vector<float> mvLevelSigma2;
-    vector<float> mvInvLevelSigma2;
+  // Scale pyramid info.
+  int mnScaleLevels;
+  float mfScaleFactor;
+  float mfLogScaleFactor;
+  vector<float> mvScaleFactors;
+  vector<float> mvInvScaleFactors;
+  vector<float> mvLevelSigma2;
+  vector<float> mvInvLevelSigma2;
 
-    // Undistorted Image Bounds (computed once).
-    static float mnMinX;
-    static float mnMaxX;
-    static float mnMinY;
-    static float mnMaxY;
+  // Undistorted Image Bounds (computed once).
+  static float mnMinX;
+  static float mnMaxX;
+  static float mnMinY;
+  static float mnMaxY;
 
-    static bool mbInitialComputations;
+  static bool mbInitialComputations;
 
   static bool usedistort_;
 
   cv::Mat &GetTcwRef() { return Tcw_; }
-  inline const Sophus::SE3d GetTcwCst() const {return FrameBase::GetTcwCst();}
+  inline const Sophus::SE3d GetTcwCst() const { return FrameBase::GetTcwCst(); }
   const cv::Mat &GetcvTcwCst() const;
 
-private:
+ private:
+  // Undistort keypoints given OpenCV distortion parameters.
+  // Only for the RGB-D case. Stereo must be already rectified!
+  // (called in the constructor).
+  void UndistortKeyPoints();
 
-    // Undistort keypoints given OpenCV distortion parameters.
-    // Only for the RGB-D case. Stereo must be already rectified!
-    // (called in the constructor).
-    void UndistortKeyPoints();
+  // Computes image bounds for the undistorted image (called in the constructor).
+  void ComputeImageBounds(const cv::Mat &imLeft);
 
-    // Computes image bounds for the undistorted image (called in the constructor).
-    void ComputeImageBounds(const cv::Mat &imLeft);
+  // Assign keypoints to the grid for speed up feature matching (called in the constructor).
+  void AssignFeaturesToGrid();
 
-    // Assign keypoints to the grid for speed up feature matching (called in the constructor).
-    void AssignFeaturesToGrid();
-
-    // Rotation, translation and camera center
-    cv::Mat mRcw;
-    cv::Mat mtcw;
-    cv::Mat mRwc;
-    cv::Mat mOw;//==mtwc, the center of the left camera in the world/cam0 frame
+  // Rotation, translation and camera center
+  cv::Mat mRcw;
+  cv::Mat mtcw;
+  cv::Mat mRwc;
+  cv::Mat mOw;  //==mtwc, the center of the left camera in the world/cam0 frame
 };
 
-//created by zzh
-// template <>//specialized
-// void Frame::SetPreIntegrationList<IMUData>(const typename std::list<IMUData>::const_iterator &begin,const typename std::list<IMUData>::const_iterator &pback);
+// created by zzh
+//  template <>//specialized
+//  void Frame::SetPreIntegrationList<IMUData>(const typename std::list<IMUData>::const_iterator &begin,const typename
+//  std::list<IMUData>::const_iterator &pback);
 template <>
-void Frame::PreIntegration<IMUData>(Frame* pLastF,const listeig(IMUData)::const_iterator &iteri,listeig(IMUData)::const_iterator iterjBack);
+void Frame::PreIntegration<IMUData>(Frame *pLastF, const listeig(IMUData)::const_iterator &iteri,
+                                    listeig(IMUData)::const_iterator iterjBack);
 template <>
-void Frame::PreIntegration<EncData>(KeyFrame* pLastKF,const listeig(EncData)::const_iterator &iteri,listeig(EncData)::const_iterator iterjBack);
+void Frame::PreIntegration<EncData>(KeyFrame *pLastKF, const listeig(EncData)::const_iterator &iteri,
+                                    listeig(EncData)::const_iterator iterjBack);
 template <>
-void Frame::PreIntegration<IMUData>(KeyFrame* pLastKF,const listeig(IMUData)::const_iterator &iteri,listeig(IMUData)::const_iterator iterjBack);
+void Frame::PreIntegration<IMUData>(KeyFrame *pLastKF, const listeig(IMUData)::const_iterator &iteri,
+                                    listeig(IMUData)::const_iterator iterjBack);
 
-}// namespace ORB_SLAM
+}  // namespace VIEO_SLAM
 
-#endif // FRAME_H
+#endif  // FRAME_H

--- a/include/FrameBase.h
+++ b/include/FrameBase.h
@@ -11,6 +11,9 @@
 #include "GeometricCamera.h"
 #include "Converter.h"
 #include "so3_extra.h"
+#include "NavState.h"
+#include <typeinfo>
+#include "OdomPreIntegrator.h"
 
 namespace VIEO_SLAM {
 class MapPoint;
@@ -18,6 +21,7 @@ class MapPoint;
 class FrameBase {
  public:
   FrameBase() {}
+  FrameBase(const double &timestamp) : mTimeStamp(timestamp) {}
   virtual ~FrameBase() {}
 
   // TODO: if Trc ref is imu, here need to be changed
@@ -29,12 +33,52 @@ class FrameBase {
   virtual void EraseMapPointMatch(const size_t &idx) { mvpMapPoints[idx] = nullptr; }
   virtual const std::vector<MapPoint *> &GetMapPointMatches() { return mvpMapPoints; }
   const std::vector<MapPoint *> &GetMapPointMatches() const { return mvpMapPoints; }
-  virtual void ReplaceMapPointMatch(const size_t &idx, MapPoint* pMP) { mvpMapPoints[idx] = pMP; }
-  virtual std::set<MapPoint*> GetMapPoints();
-  virtual std::set<std::pair<MapPoint*, size_t>> GetMapPointsCami();
+  virtual void ReplaceMapPointMatch(const size_t &idx, MapPoint *pMP) { mvpMapPoints[idx] = pMP; }
+  virtual std::set<MapPoint *> GetMapPoints();
+  virtual std::set<std::pair<MapPoint *, size_t>> GetMapPointsCami();
 
-  std::vector<GeometricCamera*> mpCameras;
+  // virtual makes it could be implemented as thread-safe one and used by PreIntegration()
+  virtual NavState GetNavState(void) {  // cannot use const &(make mutex useless)
+    return mNavState;                   // call copy constructor
+  }
+  virtual void SetNavState(const NavState &ns) { mNavState = ns; }
+  // for SetBadFlag()(just for safety, usually check mpPrevKF is enough)
+  virtual EncPreIntegrator GetEncPreInt(void) {
+    return mOdomPreIntEnc;  // won't copy list
+  }
+  virtual IMUPreintegrator GetIMUPreInt(void) {
+    return mOdomPreIntIMU;  // won't copy list
+  }
+  // Notice that here for virtual cannot be applied on template func., be careful for kf's preint op.
+  template <class OdomData>
+  void ClearOdomPreInt() {
+    mOdomPreIntEnc.mdeltatij = 0;
+  }
+  //[iteri,iterj) IMU preintegration, breset=false could make KF2KF preintegration time averaged to per frame &&
+  // connect 2KFs preintegration by only preintegrating the final KF2KF period
+  template <class OdomData, class Preintegrator>
+  int PreIntegration(typename OdomData::TTtime tm_start, typename OdomData::TTtime tm_end,
+                     const Eigen::Vector3d &bgi_bar, const Eigen::Vector3d &bai_bar,
+                     const typename aligned_list<OdomData>::const_iterator &iteri,
+                     const typename aligned_list<OdomData>::const_iterator &iterj, bool breset = true,
+                     Preintegrator *ppreint_odom = nullptr, int8_t verbose = 0) {
+    if (!ppreint_odom) ppreint_odom = &mOdomPreIntEnc;
+    return ppreint_odom->PreIntegration(tm_start, tm_end, iteri, iterj, breset);
+  }  // 0th frame don't use this function, pLastF shouldn't be bad
+  template <class OdomData>
+  void PreIntegration(FrameBase *plastfb, const typename aligned_list<OdomData>::const_iterator &iteri,
+                      const typename aligned_list<OdomData>::const_iterator &iterj, bool breset = true,
+                      int8_t verbose = 0) {
+    NavState ns = plastfb->GetNavState();  // unused for EncData, but specialized and used for IMUData
+    PreIntegration<OdomData, EncPreIntegrator>(plastfb->mTimeStamp, mTimeStamp, ns.mbg, ns.mba, iteri, iterj, breset,
+                                               nullptr, verbose);
+  }
+
+  std::vector<GeometricCamera *> mpCameras;
   std::vector<std::pair<size_t, size_t>> mapn2in_;
+
+  // Frame timestamp.
+  double mTimeStamp;
 
  protected:
   inline const Sophus::SE3d GetTcwCst() const {
@@ -48,7 +92,27 @@ class FrameBase {
 
   // Camera pose.
   cv::Mat Tcw_;
+
+  // state xi={Ri,pi,vi,bi}, this xi doesn't include landmarks' state li/mi but include the camera's state xci(for Tbc
+  // is a constant) not designed for multi threads/just used in Tracking thread in Base
+  NavState mNavState;
+  // Odom PreIntegration, j means this fb, i means last fb, if no measurements=>mdeltatij==0
+  EncPreIntegrator mOdomPreIntEnc;
+  IMUPreintegrator mOdomPreIntIMU;
 };
+
+template <>
+void FrameBase::ClearOdomPreInt<IMUData>();
+template <>
+int FrameBase::PreIntegration<IMUData, IMUPreintegrator>(IMUData::TTtime tm_start, IMUData::TTtime tm_end,
+                                                         const Eigen::Vector3d &bgi_bar, const Eigen::Vector3d &bai_bar,
+                                                         const typename aligned_list<IMUData>::const_iterator &iteri,
+                                                         const typename aligned_list<IMUData>::const_iterator &iterj,
+                                                         bool breset, IMUPreintegrator *ppreint_odom, int8_t verbose);
+template <>
+void FrameBase::PreIntegration<IMUData>(FrameBase *plastfb, const typename aligned_list<IMUData>::const_iterator &iteri,
+                                        const typename aligned_list<IMUData>::const_iterator &iterj, bool breset,
+                                        int8_t verbose);
 }  // namespace VIEO_SLAM
 
 #endif  // VIEO_SLAM_FRAMEBASE_H

--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -322,11 +322,9 @@ public:
     // KeyPoints, stereo coordinate and descriptors (all associated by an index)
     const std::vector<cv::KeyPoint> mvKeys;
     const std::vector<cv::KeyPoint> mvKeysUn;
-  std::vector<std::vector<cv::KeyPoint>> vvkeys_;
     const std::vector<float> mvuRight; // negative value for monocular points
     const std::vector<float> mvDepth; // negative value for monocular points
     const cv::Mat mDescriptors;
-  std::vector<cv::Mat> vdescriptors_;
 
     //BoW
     DBoW2::BowVector mBowVec;

--- a/include/Optimizer.h
+++ b/include/Optimizer.h
@@ -236,7 +236,7 @@ int Optimizer::PoseOptimization(Frame *pFrame, KeyFrame *pLastKF, const cv::Mat 
 
   // Set Frame & fixed KeyFrame's vertices, see VIORBSLAM paper (4)~(8)
   const int FramePVRId = 0, FrameBiasId = 1, LastKFPVRId = 2, LastKFBiasId = 3;
-  NavState &nsj = pFrame->mNavState;
+  NavState &nsj = pFrame->GetNavStateRef();
   // Set Frame vertex PVR/Bias
   g2o::VertexNavStatePVR *vNSFPVR = new g2o::VertexNavStatePVR();
   vNSFPVR->setEstimate(nsj);
@@ -261,7 +261,7 @@ int Optimizer::PoseOptimization(Frame *pFrame, KeyFrame *pLastKF, const cv::Mat 
   optimizer.addVertex(vNSKFBias);
 
   // Set IMU_I/PVR(B) edge(ternary/multi edge) between LastKF-Frame
-  const IMUPreintegrator &imupreint = pFrame->mOdomPreIntIMU;
+  const IMUPreintegrator &imupreint = pFrame->GetIMUPreInt();
   g2o::EdgeNavStatePVR *eNSPVR = new g2o::EdgeNavStatePVR();
   eNSPVR->setVertex(
       0, dynamic_cast<g2o::OptimizableGraph::Vertex *>(optimizer.vertex(LastKFPVRId)));  // PVRi, i is keyframe's id
@@ -306,9 +306,9 @@ int Optimizer::PoseOptimization(Frame *pFrame, KeyFrame *pLastKF, const cv::Mat 
   }
   // Set Enc edge(binary) between LastKF-Frame
   g2o::EdgeEncNavStatePVR *eEnc = nullptr;
-  if (pFrame->mOdomPreIntEnc.mdeltatij > 0) {
+  if (pFrame->GetEncPreInt().mdeltatij > 0) {
     // Set Enc edge(binary edge) between LastF-Frame
-    const EncPreIntegrator &encpreint = pFrame->mOdomPreIntEnc;
+    const EncPreIntegrator &encpreint = pFrame->GetEncPreInt();
     eEnc = new g2o::EdgeEncNavStatePVR();
     eEnc->setVertex(0, dynamic_cast<g2o::OptimizableGraph::Vertex *>(optimizer.vertex(LastKFPVRId)));  // lastF,i
     eEnc->setVertex(1, dynamic_cast<g2o::OptimizableGraph::Vertex *>(optimizer.vertex(FramePVRId)));   // curF,j
@@ -733,7 +733,7 @@ int Optimizer::OptimizeInitialGyroBias(const std::vector<IMUKeyFrameInit *> &vpK
   for (int i = 0; i < N; i++) {
     if (i == 0) continue;  // Ignore the first KF
     const IMUPreintegrator &imupreint =
-        vpKFInit[i]->mOdomPreIntIMU;  // notice this should be computed before calling this function
+        vpKFInit[i]->GetIMUPreInt();  // notice this should be computed before calling this function
     if (imupreint.mdeltatij == 0) continue;
     ++num_equations;
     assert(imupreint.mdeltatij > 0);

--- a/src/CameraModels/GeometricCamera.cpp
+++ b/src/CameraModels/GeometricCamera.cpp
@@ -91,7 +91,6 @@ GeometricCamera::vector<float> GeometricCamera::TriangulateMatches(
   aligned_vector<Eigen::Vector3d> normedcPs(n_cams);
   vector<Eigen::Matrix3d> Rwi(n_cams);  // if no pTwr, w means r here
   vector<Eigen::Vector3d> twi(n_cams);
-  GeometricCamera *pcam = this;
   CV_Assert(!pTwr || n_cams == pTwr->size());
   for (size_t i = 0; i < n_cams; ++i) {
     auto &pcam = (*ppcams)[i];

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -312,7 +312,6 @@ Frame::Frame(const Frame &frame)
       mvKeys(frame.mvKeys),
       mvKeysUn(frame.mvKeysUn),
       vvkeys_(frame.vvkeys_),
-      vvkeys_un_(frame.vvkeys_un_),
       mapin2n_(frame.mapin2n_),
       mvuRight(frame.mvuRight),
       mvDepth(frame.mvDepth),
@@ -757,7 +756,6 @@ void Frame::ComputeBoW() {
 void Frame::UndistortKeyPoints() {
   if (mDistCoef.at<float>(0) == 0.0 && !mpCameras.size()) {
     mvKeysUn = mvKeys;
-    vvkeys_un_ = vvkeys_;
     return;
   }
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -77,28 +77,28 @@ void Frame::UpdateNavStatePVRFromTcw() {
 //  }
 template <>
 void Frame::PreIntegration<IMUData>(Frame *pLastF, const listeig(IMUData)::const_iterator &iteri,
-                                    listeig(IMUData)::const_iterator iterjBack) {
+                                    listeig(IMUData)::const_iterator iterj) {
   Eigen::Vector3d bgi_bar = pLastF->mNavState.mbg,
                   bai_bar = pLastF->mNavState.mba;  // we can directly use mNavState here
 #ifndef TRACK_WITH_IMU
-  mOdomPreIntIMU.PreIntegration(pLastF->mTimeStamp, mTimeStamp, iteri, ++iterjBack);
+  mOdomPreIntIMU.PreIntegration(pLastF->mTimeStamp, mTimeStamp, iteri, iterj);
 #else
-  mOdomPreIntIMU.PreIntegration(pLastF->mTimeStamp, mTimeStamp, bgi_bar, bai_bar, iteri, ++iterjBack);
+  mOdomPreIntIMU.PreIntegration(pLastF->mTimeStamp, mTimeStamp, bgi_bar, bai_bar, iteri, iterj);
 #endif
 }
 template <>
 void Frame::PreIntegration<EncData>(KeyFrame *pLastKF, const listeig(EncData)::const_iterator &iteri,
-                                    listeig(EncData)::const_iterator iterjBack) {
-  mOdomPreIntEnc.PreIntegration(pLastKF->mTimeStamp, mTimeStamp, iteri, ++iterjBack);
+                                    listeig(EncData)::const_iterator iterj) {
+  mOdomPreIntEnc.PreIntegration(pLastKF->mTimeStamp, mTimeStamp, iteri, iterj);
 }
 template <>
 void Frame::PreIntegration<IMUData>(KeyFrame *pLastKF, const listeig(IMUData)::const_iterator &iteri,
-                                    listeig(IMUData)::const_iterator iterjBack) {
+                                    listeig(IMUData)::const_iterator iterj) {
   Eigen::Vector3d bgi_bar = pLastKF->GetNavState().mbg, bai_bar = pLastKF->GetNavState().mba;
 #ifndef TRACK_WITH_IMU
-  mOdomPreIntIMU.PreIntegration(pLastKF->mTimeStamp, mTimeStamp, iteri, ++iterjBack);
+  mOdomPreIntIMU.PreIntegration(pLastKF->mTimeStamp, mTimeStamp, iteri, iterj);
 #else
-  mOdomPreIntIMU.PreIntegration(pLastKF->mTimeStamp, mTimeStamp, bgi_bar, bai_bar, iteri, ++iterjBack);
+  mOdomPreIntIMU.PreIntegration(pLastKF->mTimeStamp, mTimeStamp, bgi_bar, bai_bar, iteri, iterj);
 #endif
 }
 
@@ -293,10 +293,9 @@ Frame::Frame() {}
 
 // Copy Constructor
 Frame::Frame(const Frame &frame)
-    : FrameBase(frame),
+    : FrameBase(frame),// mOdomPreIntIMU/Enc list uncopied
       mpORBvocabulary(frame.mpORBvocabulary),
       mpORBextractors(frame.mpORBextractors),
-      mTimeStamp(frame.mTimeStamp),
       mK(frame.mK.clone()),
       mDistCoef(frame.mDistCoef.clone()),
       mbf(frame.mbf),
@@ -335,9 +334,6 @@ Frame::Frame(const Frame &frame)
   if (!frame.Tcw_.empty()) SetPose(frame.Tcw_);
 
   // created by zzh
-  mOdomPreIntIMU = frame.mOdomPreIntIMU;
-  mOdomPreIntEnc = frame.mOdomPreIntEnc;  // list uncopied
-  mNavState = frame.mNavState;
   mMargCovInv = frame.mMargCovInv;
   mNavStatePrior = frame.mNavStatePrior;
   mbPrior = frame.mbPrior;
@@ -346,8 +342,8 @@ Frame::Frame(const Frame &frame)
 Frame::Frame(const vector<cv::Mat> &ims, const double &timeStamp, vector<ORBextractor *> extractors, ORBVocabulary *voc,
              cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth,
              const vector<GeometricCamera *> *pCamInsts, bool usedistort)
-    : mpORBvocabulary(voc),
-      mTimeStamp(timeStamp),
+    : FrameBase(timeStamp),
+      mpORBvocabulary(voc),
       mK(K.clone()),
       mDistCoef(distCoef.clone()),
       mbf(bf),
@@ -442,8 +438,8 @@ Frame::Frame(const vector<cv::Mat> &ims, const double &timeStamp, vector<ORBextr
 
 Frame::Frame(const cv::Mat &imGray, const cv::Mat &imDepth, const double &timeStamp, ORBextractor *extractor,
              ORBVocabulary *voc, cv::Mat &K, cv::Mat &distCoef, const float &bf, const float &thDepth)
-    : mpORBvocabulary(voc),
-      mTimeStamp(timeStamp),
+    : FrameBase(timeStamp),
+      mpORBvocabulary(voc),
       mK(K.clone()),
       mDistCoef(distCoef.clone()),
       mbf(bf),
@@ -506,8 +502,8 @@ Frame::Frame(const cv::Mat &imGray, const cv::Mat &imDepth, const double &timeSt
 
 Frame::Frame(const cv::Mat &imGray, const double &timeStamp, ORBextractor *extractor, ORBVocabulary *voc, cv::Mat &K,
              cv::Mat &distCoef, const float &bf, const float &thDepth)
-    : mpORBvocabulary(voc),
-      mTimeStamp(timeStamp),
+    : FrameBase(timeStamp),
+      mpORBvocabulary(voc),
       mK(K.clone()),
       mDistCoef(distCoef.clone()),
       mbf(bf),

--- a/src/FrameBase.cpp
+++ b/src/FrameBase.cpp
@@ -6,56 +6,74 @@
 #include "MapPoint.h"
 
 using namespace VIEO_SLAM;
-using std::set;
 using std::pair;
+using std::set;
 
-const Sophus::SE3d FrameBase::GetTwc() {
-  return GetTcw().inverse();
-}
-const Sophus::SE3d FrameBase::GetTcw() {
-  return GetTcwCst();
-}
+const Sophus::SE3d FrameBase::GetTwc() { return GetTcw().inverse(); }
+const Sophus::SE3d FrameBase::GetTcw() { return GetTcwCst(); }
 
-void FrameBase::AddMapPoint(MapPoint *pMP, const size_t &idx)
-{
+void FrameBase::AddMapPoint(MapPoint *pMP, const size_t &idx) {
   assert(mvpMapPoints.size() > idx);
-//  if (mvpMapPoints[idx] && !mvpMapPoints[idx]->isBad()) {
-//    cout << "check mpid=" << mvpMapPoints[idx]->mnId << " ";
-//    auto vobs = mvpMapPoints[idx]->GetObservations();
-//    for (auto obs : vobs) {
-//      cout << obs.first->mnId << ":";
-//      for (auto idx : obs.second) cout << idx << " ";
-//      cout << endl;
-//    }
-//    cout << endl;
-//  }
+  //  if (mvpMapPoints[idx] && !mvpMapPoints[idx]->isBad()) {
+  //    cout << "check mpid=" << mvpMapPoints[idx]->mnId << " ";
+  //    auto vobs = mvpMapPoints[idx]->GetObservations();
+  //    for (auto obs : vobs) {
+  //      cout << obs.first->mnId << ":";
+  //      for (auto idx : obs.second) cout << idx << " ";
+  //      cout << endl;
+  //    }
+  //    cout << endl;
+  //  }
   assert(!mvpMapPoints[idx] || mvpMapPoints[idx]->isBad());
-  mvpMapPoints[idx]=pMP;
+  mvpMapPoints[idx] = pMP;
 }
 
-set<MapPoint*> FrameBase::GetMapPoints()
-{
-  set<MapPoint*> s;
-  for(size_t i=0, iend=mvpMapPoints.size(); i<iend; i++)
-  {
-    if(!mvpMapPoints[i])
-      continue;
-    MapPoint* pMP = mvpMapPoints[i];
-    if(!pMP->isBad())
-      s.insert(pMP);
+set<MapPoint *> FrameBase::GetMapPoints() {
+  set<MapPoint *> s;
+  for (size_t i = 0, iend = mvpMapPoints.size(); i < iend; i++) {
+    if (!mvpMapPoints[i]) continue;
+    MapPoint *pMP = mvpMapPoints[i];
+    if (!pMP->isBad()) s.insert(pMP);
   }
   return s;
 }
 
-std::set<std::pair<MapPoint*, size_t>> FrameBase::GetMapPointsCami() {
-  set<pair<MapPoint*, size_t>> s;
+std::set<std::pair<MapPoint *, size_t>> FrameBase::GetMapPointsCami() {
+  set<pair<MapPoint *, size_t>> s;
   for (size_t i = 0, iend = mvpMapPoints.size(); i < iend; i++) {
     if (!mvpMapPoints[i]) continue;
-    MapPoint* pMP = mvpMapPoints[i];
+    MapPoint *pMP = mvpMapPoints[i];
     if (!pMP->isBad()) {
       size_t cami = mapn2in_.size() <= i ? 0 : get<0>(mapn2in_[i]);
       s.insert(make_pair(pMP, cami));
     }
   }
   return s;
+}
+
+template <>
+void FrameBase::ClearOdomPreInt<IMUData>() {
+  mOdomPreIntIMU.mdeltatij = 0;
+}
+template <>
+int FrameBase::PreIntegration<IMUData, IMUPreintegrator>(IMUData::TTtime tm_start, IMUData::TTtime tm_end,
+                                                         const Eigen::Vector3d &bgi_bar, const Eigen::Vector3d &bai_bar,
+                                                         const typename aligned_list<IMUData>::const_iterator &iteri,
+                                                         const typename aligned_list<IMUData>::const_iterator &iterj,
+                                                         bool breset, IMUPreintegrator *ppreint_odom, int8_t verbose) {
+  if (!ppreint_odom) ppreint_odom = &mOdomPreIntIMU;
+#ifndef TRACK_WITH_IMU
+  // TODO: fix this
+  return ppreint_odom->PreIntegration(tm_start, tm_end, bgi_bar, bai_bar, iteri, iterj, breset);
+#else
+  return ppreint_odom->PreIntegration(tm_start, tm_end, bgi_bar, bai_bar, iteri, iterj, breset);
+#endif
+}
+template <>
+void FrameBase::PreIntegration<IMUData>(FrameBase *plastfb, const typename aligned_list<IMUData>::const_iterator &iteri,
+                                        const typename aligned_list<IMUData>::const_iterator &iterj, bool breset,
+                                        int8_t verbose) {
+  NavState ns = plastfb->GetNavState();
+  PreIntegration<IMUData, IMUPreintegrator>(plastfb->mTimeStamp, mTimeStamp, ns.mbg, ns.mba, iteri, iterj, breset,
+                                            nullptr, verbose);
 }

--- a/src/KeyFrame.cc
+++ b/src/KeyFrame.cc
@@ -118,6 +118,7 @@ KeyFrame::KeyFrame(Frame &F, Map *pMap, KeyFrameDatabase *pKFDB,KeyFrame* pPrevK
 
   mnId = nNextId++;
   vgrids_ = F.vgrids_;
+  Tcw_.release();
   SetPose(F.GetTcwRef());  // we have already used UpdatePoseFromNS() in Frame
 
   read(is);  // set odom list & mState
@@ -232,6 +233,7 @@ KeyFrame::KeyFrame(Frame &F, Map *pMap, KeyFrameDatabase *pKFDB,KeyFrame* pPrevK
   mnId = nNextId++;
   vgrids_ = F.vgrids_;
 
+  Tcw_.release();
   SetPose(F.GetTcwRef());
   PRINT_DEBUG_INFO_MUTEX("checkkf"<<mnId<<" ", imu_tightly_debug_path, "debug.txt");
   size_t i =0;

--- a/src/KeyFrame.cc
+++ b/src/KeyFrame.cc
@@ -824,22 +824,16 @@ void KeyFrame::SetBadFlag(bool bKeepTree)//this will be released in UpdateLocalK
 	  mpPrevKeyFrame->SetNextKeyFrame(mpNextKeyFrame);//mpNextKeyFrame here cannot be NULL for mpCurrentKF cannot be erased in KFCulling()
 	  mpNextKeyFrame->SetPrevKeyFrame(mpPrevKeyFrame);//0th KF cannot be erased so mpPrevKeyFrame cannot be NULL
 	  //AppendIMUDataToFront, qIMU can speed up!
-	  listeig(IMUData) limunew=mpNextKeyFrame->GetListIMUData();//notice GetIMUPreInt() doesn't copy list!
 	  {
 	    unique_lock<mutex> lock(mMutexOdomData);
-//            auto &lodom = mOdomPreIntIMU.GetRawDataRef();
-//            mpNextKeyFrame->AppendFrontPreIntegrationList<IMUData>(lodom, lodom.begin(), lodom.end());
-            limunew.insert(limunew.begin(),mOdomPreIntIMU.getlOdom().begin(),mOdomPreIntIMU.getlOdom().end());
-            mpNextKeyFrame->SetPreIntegrationList<IMUData>(limunew.begin(),limunew.end());
+            auto &lodom = mOdomPreIntIMU.GetRawDataRef();
+            mpNextKeyFrame->AppendFrontPreIntegrationList<IMUData>(lodom, lodom.begin(), lodom.end());
 	  }
 	  //AppendEncDataToFront
-	  listeig(EncData) lencnew=mpNextKeyFrame->GetListEncData();//notice GetEncPreInt() doesn't copy list!
           {
 	    unique_lock<mutex> lock(mMutexOdomData);
-	    lencnew.insert(lencnew.begin(),mOdomPreIntEnc.getlOdom().begin(),mOdomPreIntEnc.getlOdom().end());
-            mpNextKeyFrame->SetPreIntegrationList<EncData>(lencnew.begin(),lencnew.end());
-//            auto &lodom = mOdomPreIntEnc.GetRawDataRef();
-//            mpNextKeyFrame->AppendFrontPreIntegrationList<EncData>(lodom, lodom.begin(), lodom.end());
+            auto &lodom = mOdomPreIntEnc.GetRawDataRef();
+            mpNextKeyFrame->AppendFrontPreIntegrationList<EncData>(lodom, lodom.begin(), lodom.end());
 	  }
 	  //ComputePreInt
 	  mpNextKeyFrame->PreIntegration<IMUData>(mpPrevKeyFrame);

--- a/src/KeyFrame.cc
+++ b/src/KeyFrame.cc
@@ -116,10 +116,6 @@ KeyFrame::KeyFrame(Frame &F, Map *pMap, KeyFrameDatabase *pKFDB,KeyFrame* pPrevK
   mpNextKeyFrame = NULL;    // zzh, constructor doesn't need to lock mutex
   mNavState = F.mNavState;  // we don't update bias for convenience in LoadMap(), though we can do it as mOdomPreIntOdom is updated in read()
 
-  vvkeys_ = F.vvkeys_;
-  vdescriptors_.resize(F.vdescriptors_.size());
-  for (size_t i = 0; i < F.vdescriptors_.size(); ++i) vdescriptors_[i] = F.vdescriptors_[i].clone();
-
   mnId = nNextId++;
   vgrids_ = F.vgrids_;
   SetPose(F.GetTcwRef());  // we have already used UpdatePoseFromNS() in Frame
@@ -231,10 +227,6 @@ KeyFrame::KeyFrame(Frame &F, Map *pMap, KeyFrameDatabase *pKFDB,KeyFrame* pPrevK
   mNavState.mba += mNavState.mdba;
   mNavState.mdbg = mNavState.mdba =
       Eigen::Vector3d::Zero();  // update bi (bi=bi+dbi) for a better PreIntegration of nextKF(localBA) & fixedlastKF motion-only BA of next Frame(this won't optimize lastKF.mdbi any more)
-
-  vvkeys_ = F.vvkeys_;
-  vdescriptors_.resize(F.vdescriptors_.size());
-  for (size_t i = 0; i < F.vdescriptors_.size(); ++i) vdescriptors_[i] = F.vdescriptors_[i].clone();
   // created by zzh over
 
   mnId = nNextId++;

--- a/src/MapPoint.cc
+++ b/src/MapPoint.cc
@@ -92,6 +92,7 @@ MapPoint::MapPoint(const cv::Mat &Pos, Map* pMap, Frame* pFrame, const int &idxF
 {
     Pos.copyTo(mWorldPos);
     //similar to part in the StereoInitialization(): Update Normal&Depth Compute Descriptor
+    // TODO(zzh): check dist&level from multicams instead of current ref cam 0
     cv::Mat Ow = pFrame->GetCameraCenter();
     mNormalVector = mWorldPos - Ow;
     mNormalVector = mNormalVector/cv::norm(mNormalVector);//normalized normal vector
@@ -444,6 +445,7 @@ void MapPoint::UpdateNormalAndDepth() {
     }
   }
 
+  // TODO(zzh): check dist&level from multicams instead of current ref cam 0
   cv::Mat PC = Pos - pRefKF->GetCameraCenter();
   const float dist =
       cv::norm(PC);  // why not dist*cos(theta)? then we have deltaPatch'/deltaPatch=dist/dist'(without rotation)

--- a/src/Odom/IMUInitialization.h
+++ b/src/Odom/IMUInitialization.h
@@ -188,6 +188,7 @@ public:
   IMUKeyFrameInit(KeyFrame& kf);
 
   cv::Mat &GetTcwRef() { return mTcw; }
+  const IMUPreintegrator &GetIMUPreInt(void) const { return mOdomPreIntIMU; }
   
   void ComputePreInt(){//0th frame don't use this function, mpPrevKeyFrame shouldn't be bad
     if (mpPrevKeyFrame==NULL) return;

--- a/src/Odom/OdomData.h
+++ b/src/Odom/OdomData.h
@@ -31,6 +31,7 @@ class IMUDataBase
 { 
   static double mdMultiplyG;//IMU.dMultiplyG for getting right scaled accelerate
 public:
+ typedef double TTtime;
   static double mdRefG;//referenced G for IV-C in VIORBSLAM paper
   static Matrix3d mSigmag,mSigmaa,mSigmabg,mSigmaba;//b means bias/Brownian motion(Random walk), g means gyroscope, a means accelerator, d means discrete but here may continuous one, Sigma means Covariance Matrix
   static double mInvSigmabg2,mInvSigmaba2;//when mSigmabi is always diagonal matrix, use this to speed up infomation matrix calculation
@@ -129,6 +130,7 @@ typedef Eigen::Matrix<double, 6, 6> Matrix6d;
 
 class EncData{
 public:
+ typedef double TTtime;
   static double mvscale;//encoder coefficient to m/s
   static double mrc;//rc: 2 differential driving wheels' distance
   static Matrix2d mSigma;// mSigma Sigma eta of Enc, when mdt_cov_noise_fixed*mFreqRef!=0 it means discrete one

--- a/src/Odom/OdomPreIntegrator.cpp
+++ b/src/Odom/OdomPreIntegrator.cpp
@@ -12,12 +12,16 @@ namespace VIEO_SLAM{
 
 using namespace Eigen;
 
-void EncPreIntegrator::PreIntegration(const double &timeStampi,const double &timeStampj,
-				      const listeig(EncData)::const_iterator &iterBegin,const listeig(EncData)::const_iterator &iterEnd){
-  if (iterBegin!=iterEnd&&timeStampi<timeStampj){//timeStampi may >=timeStampj for Map Reuse
-    Vector2d eigdeltaPijM(0,0);//deltaPii=0
-    double deltaThetaijMz=0;//deltaTheta~iiz=0
-    mSigmaEij.setZero();//SigmaEii=0
+void EncPreIntegrator::reset() {
+  eigdeltaPijM = Vector2d(0,0);//deltaPii=0
+  deltaThetaijMz = 0;//deltaTheta~iiz=0
+  mSigmaEij.setZero();//SigmaEii=0
+}
+
+int EncPreIntegrator::PreIntegration(const double &timeStampi,const double &timeStampj,
+				      const listeig(EncData)::const_iterator &iterBegin,const listeig(EncData)::const_iterator &iterEnd, bool breset){
+  if (iterBegin!=iterEnd){//timeStampi may >=timeStampj for Map Reuse
+    if (breset) reset();
     const double EPS = 1E-5;
     
 //     listeig(EncData)::const_iterator it=iterEnd;
@@ -43,7 +47,7 @@ void EncPreIntegrator::PreIntegration(const double &timeStampi,const double &tim
       deltat=tj-tj_1;
       if (deltat==0) continue;
 //       assert(deltat>=0);
-      if (deltat>1.5){ mdeltatij=0;cout<<redSTR"Check Odometry!"<<whiteSTR<<endl;return;}//this filter is for the problem of my dataset which only contains encoder data
+      if (deltat>1.5){ mdeltatij=0;cout<<redSTR"Check Odometry!"<<whiteSTR<<endl;return -1;}//this filter is for the problem of my dataset which only contains encoder data
       
       //selete/design measurement_j-1
       double vl,vr;//vlj-1,vrj-1
@@ -122,6 +126,7 @@ void EncPreIntegrator::PreIntegration(const double &timeStampi,const double &tim
     mdelxEij[0]=mdelxEij[1]=mdelxEij[5]=0;mdelxEij[2]=deltaThetaijMz;mdelxEij.segment<2>(3)=eigdeltaPijM;
     mdeltatij=timeStampj-timeStampi;
   }
+  return 0;
 }
 void IMUPreIntegratorDerived::PreIntegration(const double &timeStampi,const double &timeStampj){
   if (!this->mlOdom.empty()){

--- a/src/Odom/OdomPreIntegrator.h
+++ b/src/Odom/OdomPreIntegrator.h
@@ -139,7 +139,7 @@ template<class IMUDataBase>
 int IMUPreIntegratorBase<IMUDataBase>::PreIntegration(const double &timeStampi,const double &timeStampj,const Vector3d &bgi_bar,const Vector3d &bai_bar,
 						       const typename listeig(IMUDataBase)::const_iterator &iterBegin,const typename listeig(IMUDataBase)::const_iterator &iterEnd, bool breset){
   //TODO: refer to the code by JingWang
-  if (iterBegin!=iterEnd&&timeStampi<timeStampj){//default parameter = !mlOdom.empty(); timeStampi may >=timeStampj for Map Reuse
+  if (iterBegin!=iterEnd){//default parameter = !mlOdom.empty(); timeStampi may >=timeStampj for Map Reuse
     // Reset pre-integrator first
     if (breset) reset();
     // remember to consider the gap between the last KF and the first IMU

--- a/src/Odom/OdomPreIntegrator.h
+++ b/src/Odom/OdomPreIntegrator.h
@@ -12,46 +12,41 @@ namespace VIEO_SLAM{
 
     using Eigen::Quaterniond;
     using Eigen::Matrix;
-  
+
 template<class _OdomData>
 class OdomPreIntegratorBase{//base class
   OdomPreIntegratorBase(const OdomPreIntegratorBase &pre){}//don't want the list to be copied (e.g. by derived class)
   OdomPreIntegratorBase& operator=(const OdomPreIntegratorBase &other){;return *this;}//do nothing, don't want the list to be assigned in any situation, this makes the derived class unable to use default =!
-  
+
 protected:
   listeig(_OdomData) mlOdom;//for IMUPreIntegrator: IMU list
-  
+
 public:
+ template <class T>
+ using aligned_list = Eigen::aligned_list<T>;
+
   double mdeltatij;//0 means not preintegrated
-  
+
   OdomPreIntegratorBase():mdeltatij(0){}
   //though copy constructor/operator = already deep, please don't copy the list when preintegration is not related to the statei...j
   virtual ~OdomPreIntegratorBase(){}
   // Odom PreIntegration List Setting
-  virtual void SetPreIntegrationList(const typename listeig(_OdomData)::const_iterator &begin,typename listeig(_OdomData)::const_iterator pback){
+  virtual void SetPreIntegrationList(const typename listeig(_OdomData)::const_iterator &begin,typename listeig(_OdomData)::const_iterator end){
     mlOdom.clear();
-    mlOdom.insert(mlOdom.begin(),begin,++pback);
+    mlOdom.insert(mlOdom.begin(),begin,end);
+  }
+  // splice operation (like move) for fast append
+  virtual void AppendFrontPreIntegrationList(aligned_list<_OdomData> &x,
+                                             const typename aligned_list<_OdomData>::const_iterator &begin,
+                                             const typename aligned_list<_OdomData>::const_iterator &end) {
+    mlOdom.splice(mlOdom.begin(), x, begin, end);
   }
   const listeig(_OdomData)& getlOdom(){return mlOdom;}//the list of Odom, for KFCulling()
+  // the list of Odom, for deep proc(like KFCulling())
+  aligned_list<_OdomData> &GetRawDataRef() { return mlOdom; }
   // Odom PreIntegration
   virtual void PreIntegration(const double timeStampi,const double timeStampj){assert(0&&"You called an empty virtual function!!!");}//cannot use =0 for we allow transformed in derived class
-  
-  // normalize to avoid numerical error accumulation
-  inline Quaterniond normalizeRotationQ(const Quaterniond& r) const
-  {
-    Quaterniond _r(r);
-    if (_r.w()<0)//is this necessary?
-    {
-	_r.coeffs() *= -1;
-    }
-    return _r.normalized();
-  }
-  inline Matrix3d normalizeRotationM(const Matrix3d& R) const
-  {
-    Quaterniond qr(R);
-    return normalizeRotationQ(qr).toRotationMatrix();
-  }
-  
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
@@ -60,10 +55,13 @@ typedef Eigen::Matrix<double, 6, 1> Vector6d;
 //next derived classes don't use operator=!
 class EncPreIntegrator:public OdomPreIntegratorBase<EncData>{
   //mlOdom: mlOdomEnc list for vl,vr& its own timestamp
+  void reset();
+  Eigen::Vector2d eigdeltaPijM;//deltaPii=0
+  double deltaThetaijMz;
 public:
   Vector6d mdelxEij;// delta~Phiij(3*1),delta~pij(3*1) from Encoder PreIntegration, 6*1*float
   Matrix6d mSigmaEij;// by Enc, 6*6*float
-  
+
   EncPreIntegrator():mdelxEij(Vector6d::Zero()),mSigmaEij(Matrix6d::Zero()){}
   EncPreIntegrator(const EncPreIntegrator &pre):mdelxEij(pre.mdelxEij),mSigmaEij(pre.mSigmaEij){mdeltatij=pre.mdeltatij;}//don't copy list!
   EncPreIntegrator& operator=(const EncPreIntegrator &pre){
@@ -71,10 +69,10 @@ public:
     mdelxEij=pre.mdelxEij;mSigmaEij=pre.mSigmaEij;
     return *this;
   }
-  void PreIntegration(const double &timeStampi,const double &timeStampj,
-		      const listeig(EncData)::const_iterator &iterBegin,const listeig(EncData)::const_iterator &iterEnd);//rewrite
+  int PreIntegration(const double &timeStampi,const double &timeStampj,
+		      const listeig(EncData)::const_iterator &iterBegin,const listeig(EncData)::const_iterator &iterEnd, bool breset = true);//rewrite
   void PreIntegration(const double &timeStampi,const double &timeStampj){PreIntegration(timeStampi,timeStampj,mlOdom.begin(),mlOdom.end());}//rewrite, inline
-  
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 
@@ -83,6 +81,8 @@ typedef Eigen::Matrix<double, 9, 9> Matrix9d;
 template<class IMUDataBase>
 class IMUPreIntegratorBase:public OdomPreIntegratorBase<IMUDataBase>{//refer the IMUPreintergrator.cpp by JingWang, so use PVR/PRV Cov.
 public:
+ typedef double Tcalc;
+ using SO3calc = Sophus::SO3ex<Tcalc>;
   Matrix3d mRij;//deltaR~ij(bgi_bar) by awIMU, 3*3*float/delta~Rbibj
   Vector3d mvij,mpij;//deltav~ij,deltap~ij(bi_bar)
   Matrix9d mSigmaijPRV;//Cov_p_Phi_v_ij, a bit different with paper for convenience
@@ -99,7 +99,7 @@ public:
     Matrix3d mRij_hf;//deltaR~ij(bgi_bar) by awIMU, 3*3*float/delta~Rbibj
     Vector3d mvij_hf,mpij_hf;//deltav~ij,deltap~ij(bi_bar)
     double mdt_hf, mdt_hf_ref;
-  
+
   IMUPreIntegratorBase():mRij(Matrix3d::Identity()),mvij(0,0,0),mpij(0,0,0),mSigmaijPRV(Matrix9d::Zero()),mSigmaij(Matrix9d::Zero()){
     mJgpij.setZero();mJapij.setZero();mJgvij.setZero();mJavij.setZero();mJgRij.setZero();
   }
@@ -114,16 +114,16 @@ public:
     return *this;
   }
   virtual ~IMUPreIntegratorBase(){}
-  
-  void PreIntegration(const double &timeStampi,const double &timeStampj,const Vector3d &bgi_bar,const Vector3d &bai_bar,
-		      const typename listeig(IMUDataBase)::const_iterator &iterBegin,const typename listeig(IMUDataBase)::const_iterator &iterEnd);//rewrite, like override but different
+
+  int PreIntegration(const double &timeStampi,const double &timeStampj,const Vector3d &bgi_bar,const Vector3d &bai_bar,
+		      const typename listeig(IMUDataBase)::const_iterator &iterBegin,const typename listeig(IMUDataBase)::const_iterator &iterEnd, bool breset = true);//rewrite, like override but different
   void PreIntegration(const double &timeStampi,const double &timeStampj,const Vector3d &bgi_bar,const Vector3d &bai_bar){//inline
     PreIntegration(timeStampi,timeStampj,bgi_bar,bai_bar,this->mlOdom.begin(),this->mlOdom.end());
   }//rewrite
   // incrementally update 1)delta measurements, 2)jacobians, 3)covariance matrix
   void update(const Vector3d& omega, const Vector3d& acc, const double& dt);//don't allow dt<0!
   void update_highfreq(const Vector3d& omega, const Vector3d& acc, const double& dt);//don't allow dt<0!
-  
+
   // reset to initial state
   void reset(){
     mRij.setIdentity();mvij.setZero();mpij.setZero();mSigmaijPRV.setZero();mSigmaij.setZero();
@@ -133,35 +133,30 @@ public:
       mdt_hf = 0;
       mdt_hf_ref = 1. / 105;//60;//
   }
-  
-  // exponential map from vec3 to mat3x3 (Rodrigues formula)
-  static Matrix3d Expmap(const Vector3d& v){//here is inline, but defined in .cpp is ok for efficiency due to copy elision(default gcc -O2 uses it) when return a temporary variable(NRVO/URVO)
-    return Sophus::SO3exd::exp(v).matrix();//here is URVO
-  }
 };
 //when template<>: specialized definition should be defined in .cpp(avoid redefinition) or use inline/static(not good) in .h and template func. in template class can't be specialized(only fully) when its class is not fully specialized
 template<class IMUDataBase>
-void IMUPreIntegratorBase<IMUDataBase>::PreIntegration(const double &timeStampi,const double &timeStampj,const Vector3d &bgi_bar,const Vector3d &bai_bar,
-						       const typename listeig(IMUDataBase)::const_iterator &iterBegin,const typename listeig(IMUDataBase)::const_iterator &iterEnd){
+int IMUPreIntegratorBase<IMUDataBase>::PreIntegration(const double &timeStampi,const double &timeStampj,const Vector3d &bgi_bar,const Vector3d &bai_bar,
+						       const typename listeig(IMUDataBase)::const_iterator &iterBegin,const typename listeig(IMUDataBase)::const_iterator &iterEnd, bool breset){
   //TODO: refer to the code by JingWang
   if (iterBegin!=iterEnd&&timeStampi<timeStampj){//default parameter = !mlOdom.empty(); timeStampi may >=timeStampj for Map Reuse
     // Reset pre-integrator first
-    reset();
+    if (breset) reset();
     // remember to consider the gap between the last KF and the first IMU
     // integrate each imu
     IMUDataBase imu_last;
     double t_last;
     for (typename listeig(IMUDataBase)::const_iterator iterj=iterBegin;iterj!=iterEnd;){
       typename listeig(IMUDataBase)::const_iterator iterjm1=iterj++;//iterj-1
-      
+
       // delta time
       double dt,tj,tj_1;
       if (iterjm1==iterBegin) tj_1=timeStampi; else tj_1=iterjm1->mtm;
       if (iterj==iterEnd) tj=timeStampj; else{ tj=iterj->mtm;assert(tj-tj_1>=0);}
       dt=tj-tj_1;
       if (dt==0) continue;//for we use [nearest imu data at timeStampi, nearest but <=timeStampj] or [/(timeStampi,timeStampj], when we concate them in KeyFrameCulling(), dt may be 0
-      if (dt>1.5){ this->mdeltatij=0;std::cout<<"CheckIMU!!!"<<std::endl;return;}//for Map Reuse, the edge between last KF of the map and 0th KF of 2nd SLAM should have no odom info (20frames,>=10Hz, 1.5s<=2s is enough for not using MAP_REUSE_RELOC)
-      
+      if (dt>1.5){ this->mdeltatij=0;std::cout<<"CheckIMU!!!"<<std::endl;return -1;}//for Map Reuse, the edge between last KF of the map and 0th KF of 2nd SLAM should have no odom info (20frames,>=10Hz, 1.5s<=2s is enough for not using MAP_REUSE_RELOC)
+
       //selete/design measurement_j-1
       const IMUDataBase& imu=*iterjm1;//imuj-1 for w~j-1 & a~j-1 chooses imu(tj-1), maybe u can try (imu(tj-1)+imu(tj))/2 or other filter here
 //      IMUDataBase imu=*iterjm1, imu_now = iterj != iterEnd ? *iterj : iterjm1 != iterBegin ? imu_last : imu;//(interplot)
@@ -276,18 +271,19 @@ void IMUPreIntegratorBase<IMUDataBase>::PreIntegration(const double &timeStampi,
       update(imu.mw-bgi_bar,imu.ma-bai_bar,dt);
     }
   }
+  return 0;
 }
 template<class IMUDataBase>
 void IMUPreIntegratorBase<IMUDataBase>::update(const Vector3d& omega, const Vector3d& acc, const double& dt){
   using namespace Sophus;
   using namespace Eigen;
   double dt2div2=dt*dt/2;
-  Matrix3d dR=Expmap(omega*dt);//Exp((w~j-1 - bgi_bar)*dtj-1j)=delta~Rj-1j
+  Matrix3d dR=SO3calc::Expmap(omega*dt);//Exp((w~j-1 - bgi_bar)*dtj-1j)=delta~Rj-1j
   Matrix3d Jr=SO3exd::JacobianR(omega*dt);//Jrj-1=Jr(dtj-1j*(w~j-1 - bgi_bar))
   Matrix3d skewa=SO3exd::hat(acc);//(~aj-1 - bai_bar)^
 
   //see paper On-Manifold Preintegration (63), notice PRV is different from paper RVP, but the BgBa is the same(A change row&col, B just change row)
-  // err_k+1 = A*err_k + Bg*err_gyro + Ba*err_acc; or Bj-1=[Bg Ba],Aj-1=A 
+  // err_k+1 = A*err_k + Bg*err_gyro + Ba*err_acc; or Bj-1=[Bg Ba],Aj-1=A
   Matrix3d I3x3 = Matrix3d::Identity();
   Matrix<double,9,9> A = Matrix9d::Identity();
   A.block<3,3>(3,3) = dR.transpose();
@@ -322,7 +318,7 @@ void IMUPreIntegratorBase<IMUDataBase>::update(const Vector3d& omega, const Vect
     mSigmaij=A*mSigmaij*A.transpose()+Bg*(IMUDataBase::mSigmag/dt)*Bg.transpose()+Ba*(IMUDataBase::mSigmaa/dt)*Ba.transpose();
   else
     mSigmaij=A*mSigmaij*A.transpose()+Bg*(IMUDataBase::mSigmag*IMUDataBase::mFreqRef)*Bg.transpose()+Ba*(IMUDataBase::mSigmaa*IMUDataBase::mFreqRef)*Ba.transpose();
-  
+
   //see the same paper (69) & use similar iterative rearrange method (59)
   // jacobian of delta measurements w.r.t bias of gyro/acc, for motion_update_with_dbi & residual error & J_error_dxi,xj calculation
   // update P first, then V, then R for using ij as ij-1 term
@@ -331,13 +327,13 @@ void IMUPreIntegratorBase<IMUDataBase>::update(const Vector3d& omega, const Vect
   mJavij += -mRij*dt;
   mJgvij += -mRij*skewa*mJgRij*dt;//notice except mJgRij use dR, the other Jxxij use mRij!
   mJgRij = dR.transpose()*mJgRij - Jr*dt;//like (59): JgRij=delta~Rj-1j.t()*JgRij-1 - Jrj-1*dtj-1j, the left incremental formula is easy to get for there's no j label
-  
+
   //see paper On-Manifold Preintegration (35~37)
   mpij+=mvij*dt+mRij*(acc*dt2div2);//delta~pij=delta~pij-1 + delta~vij-1*dtj-1j + 1/2*delta~Rij-1*(~aj-1 - bai_bar)*dtj-1j^2
   mvij+=mRij*(acc*dt);//here mRij=mRij-1, delta~vij=delta~vij-1 + delta~Rij-1 * (~aj-1 - bai_bar)*dtj-1j
   // normalize rotation, in case of numerical error accumulation
-  mRij=this->normalizeRotationM(mRij*dR);//here omega=(w~k-bgi_bar)(k=j-1), deltaR~ij(bgi_bar)=deltaRij-1(bgi_bar) * Exp((w~j-1 - bgi_bar)*dtj-1j)
-  
+  mRij=SO3calc::normalizeRotationM(mRij*dR);//here omega=(w~k-bgi_bar)(k=j-1), deltaR~ij(bgi_bar)=deltaRij-1(bgi_bar) * Exp((w~j-1 - bgi_bar)*dtj-1j)
+
   this->mdeltatij+=dt;
 }
 
@@ -346,13 +342,13 @@ void IMUPreIntegratorBase<IMUDataBase>::update(const Vector3d& omega, const Vect
         using namespace Sophus;
         using namespace Eigen;
         double dt2div2=dt*dt/2;
-        Matrix3d dR=Expmap(omega*dt);//Exp((w~j-1 - bgi_bar)*dtj-1j)=delta~Rj-1j
+        Matrix3d dR=SO3calc::Expmap(omega*dt);//Exp((w~j-1 - bgi_bar)*dtj-1j)=delta~Rj-1j
 
         //see paper On-Manifold Preintegration (35~37)
         mpij_hf+=mvij_hf*dt+mRij_hf*(acc*dt2div2);//delta~pij=delta~pij-1 + delta~vij-1*dtj-1j + 1/2*delta~Rij-1*(~aj-1 - bai_bar)*dtj-1j^2
         mvij_hf+=mRij_hf*(acc*dt);//here mRij=mRij-1, delta~vij=delta~vij-1 + delta~Rij-1 * (~aj-1 - bai_bar)*dtj-1j
         // normalize rotation, in case of numerical error accumulation
-        mRij_hf=this->normalizeRotationM(mRij_hf*dR);//here omega=(w~k-bgi_bar)(k=j-1), deltaR~ij(bgi_bar)=deltaRij-1(bgi_bar) * Exp((w~j-1 - bgi_bar)*dtj-1j)
+        mRij_hf=SO3calc::normalizeRotationM(mRij_hf*dR);//here omega=(w~k-bgi_bar)(k=j-1), deltaR~ij(bgi_bar)=deltaRij-1(bgi_bar) * Exp((w~j-1 - bgi_bar)*dtj-1j)
     }
 
 class IMUPreIntegratorDerived:public IMUPreIntegratorBase<IMUDataDerived>{
@@ -361,12 +357,14 @@ public:
   Matrix3d mSigmaPhiij;// SigmaPhiij by qIMU, 3*3*float
 
   IMUPreIntegratorDerived():mdelxRji(Matrix3d::Identity()),mSigmaPhiij(Matrix3d::Zero()){}
-  void SetPreIntegrationList(const listeig(IMUDataDerived)::const_iterator &begin,const listeig(IMUDataDerived)::const_iterator &pback){//rewrite, will override the base class one
+  void SetPreIntegrationList(const listeig(IMUDataDerived)::const_iterator &begin,const listeig(IMUDataDerived)::const_iterator &end){//rewrite, will override the base class one
     this->mlOdom.clear();
+    auto pback = end;
+    --pback;
     this->mlOdom.push_front(*begin);this->mlOdom.push_back(*pback);
   }
   void PreIntegration(const double &timeStampi,const double &timeStampj);//rewrite
-  
+
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };
 

--- a/src/Odom/g2otypes.h
+++ b/src/Odom/g2otypes.h
@@ -770,7 +770,7 @@ void EdgeNavStateI<NV>::linearizeOplus() {
   JPRVi.block<3, 3>(idR, idV) = O3x3;  // J_rRij_dvi
   // right is Exp(rdeltaRij).t(), same as Sophus::SO3exd::exp(rPhiij).inverse().matrix()
   //  J_rRij_ddbgi, notice Jr_b=Jr(Jg_deltaR*dbgi)
-  JBiasi.block<3, 3>(idR, 0) = -Jrinv * IMUPreintegrator::Expmap(-eR) *
+  JBiasi.block<3, 3>(idR, 0) = -Jrinv * Sophus::SO3exd::Expmap(-eR) *
                                Sophus::SO3exd::JacobianR(_measurement.mJgRij * dbgi) * _measurement.mJgRij;
   JBiasi.block<3, 3>(idR, 3) = O3x3;  // J_rRij_ddbai
   // J_rRij_dxj
@@ -858,7 +858,7 @@ class EdgeGyrBias : public BaseUnaryEdge<3, Vector3d, VertexGyrBias> {
   void computeError() {  // part of EdgeNavStateI
     const VertexGyrBias* v = static_cast<const VertexGyrBias*>(_vertices[0]);
     Vector3d bg = v->estimate();                           // bgi, here we think bg_=0, dbgi=bgi, see VIORBSLAM IV-A
-    Matrix3d dRbg = IMUPreintegrator::Expmap(JgRij * bg);  // right dR caused by dbgi
+    Matrix3d dRbg = Sophus::SO3exd::Expmap(JgRij * bg);  // right dR caused by dbgi
     Sophus::SO3exd errR((deltaRij * dRbg).transpose() * Rwbi.transpose() * Rwbj);  // deltaRij^T * Riw * Rwj
     _error = errR.log();  // eR=Log((deltaRij*Exp(Jg_deltaR*dbgi)).t()*Rbiw*Rwbj), _error.segment<3>(0) is _error itself
   }
@@ -869,7 +869,7 @@ class EdgeGyrBias : public BaseUnaryEdge<3, Vector3d, VertexGyrBias> {
     Matrix3d Jrinv = Sophus::SO3exd::JacobianRInv(_error);  // JrInv_rPhi/Jrinv_rdeltaRij/Jrinv_eR
     _jacobianOplusXi =
         -Jrinv *
-        IMUPreintegrator::Expmap(
+        Sophus::SO3exd::Expmap(
             -_error) *  // right is Exp(rdeltaRij).t(), same as Sophus::SO3exd::exp(rPhiij).inverse().matrix()
         Sophus::SO3exd::JacobianR(JgRij * bg) *
         JgRij;  // J_rRij_ddbgi(3*3), notice Jr_b=Jr(Jg_deltaR*dbgi), here dbgi=bgi or bg

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -162,18 +162,18 @@ void Tracking::PreIntegration(const int8_t type){
     else
       plastfb = static_cast<FrameBase*>(mpLastKeyFrame);
     pcurfb = static_cast<FrameBase*>(&mCurrentFrame);
-    bool bpreint = PreIntegration<EncData>(type, mlOdomEnc, miterLastEnc, plastfb, pcurfb, nullptr);//mpLastKeyFrame);
-/*    if (!bpreint)
+    bool bpreint = PreIntegration<EncData>(type, mlOdomEnc, miterLastEnc, plastfb, pcurfb, mpLastKeyFrame);
+    if (!bpreint)
       brecompute_kf2kfpreint_[0] = true;
     else if (type == 3)
-      brecompute_kf2kfpreint_[0] = false;*/
+      brecompute_kf2kfpreint_[0] = false;
     //   cout<<"!"<<mlOdomIMU.size()<<endl;
     //   cout<<"encdata over"<<endl;
     bpreint = PreIntegration<IMUData>(type, mlOdomIMU, miterLastIMU, plastfb, pcurfb, mpLastKeyFrame);
-/*    if (!bpreint)
+    if (!bpreint)
       brecompute_kf2kfpreint_[1] = true;
     else if (type == 3)
-      brecompute_kf2kfpreint_[1] = false;*/
+      brecompute_kf2kfpreint_[1] = false;
     //   cout<<"over"<<endl;
   } else {
     plastfb = static_cast<FrameBase*>(mpLastKeyFrame);
@@ -201,11 +201,11 @@ bool Tracking::GetVelocityByEnc(bool bMapUpdated) {
     FrameBase *plastfb, *pcurfb;
     plastfb = static_cast<FrameBase*>(&mLastFrame);
     pcurfb = static_cast<FrameBase*>(&mCurrentFrame);
-    bool bpreint = PreIntegration<EncData>(type, mlOdomEnc, miterLastEnc, plastfb, pcurfb, nullptr);//mpLastKeyFrame);
-/*    if (!bpreint)
+    bool bpreint = PreIntegration<EncData>(type, mlOdomEnc, miterLastEnc, plastfb, pcurfb, mpLastKeyFrame);
+    if (!bpreint)
       brecompute_kf2kfpreint_[0] = true;
     else if (type == 3)
-      brecompute_kf2kfpreint_[0] = false;*/
+      brecompute_kf2kfpreint_[0] = false;
   }
   if (mCurrentFrame.GetEncPreInt().mdeltatij == 0) {
     return false;  // check PreIntegration() failed when mdeltatij==0, so mCurrentFrame.mTcw==cv::Mat()

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -152,35 +152,60 @@ void Tracking::TrackWithOnlyOdom(bool bMapUpdated){
 }
 
 
-void Tracking::PreIntegration(const char type){
+void Tracking::PreIntegration(const int8_t type){
   unique_lock<mutex> lock(mMutexOdom);
   PRINT_DEBUG_INFO_MUTEX("type="<<(int)type<<"...", imu_tightly_debug_path, "debug.txt");
-  PreIntegration<EncData>(type,mlOdomEnc,miterLastEnc);
-//   cout<<"!"<<mlOdomIMU.size()<<endl;
-//   cout<<"encdata over"<<endl;
-  PreIntegration<IMUData>(type,mlOdomIMU,miterLastIMU);
-//   cout<<"over"<<endl;
-  /*
-  if (!mpIMUInitiator->GetVINSInited()) return;
-  if (type==1||type==3) ++gnCheck;
-  static unsigned int lastRelocId=mnLastRelocFrameId;
-  static bool firstEnter=true;*/
+  FrameBase* plastfb, *pcurfb;
+  if (type == 1 || type == 3) {
+    if (type == 1)
+      plastfb = static_cast<FrameBase*>(&mLastFrame);
+    else
+      plastfb = static_cast<FrameBase*>(mpLastKeyFrame);
+    pcurfb = static_cast<FrameBase*>(&mCurrentFrame);
+    bool bpreint = PreIntegration<EncData>(type, mlOdomEnc, miterLastEnc, plastfb, pcurfb, nullptr);//mpLastKeyFrame);
+/*    if (!bpreint)
+      brecompute_kf2kfpreint_[0] = true;
+    else if (type == 3)
+      brecompute_kf2kfpreint_[0] = false;*/
+    //   cout<<"!"<<mlOdomIMU.size()<<endl;
+    //   cout<<"encdata over"<<endl;
+    bpreint = PreIntegration<IMUData>(type, mlOdomIMU, miterLastIMU, plastfb, pcurfb, mpLastKeyFrame);
+/*    if (!bpreint)
+      brecompute_kf2kfpreint_[1] = true;
+    else if (type == 3)
+      brecompute_kf2kfpreint_[1] = false;*/
+    //   cout<<"over"<<endl;
+  } else {
+    plastfb = static_cast<FrameBase*>(mpLastKeyFrame);
+    pcurfb = type == 2 ? static_cast<FrameBase*>(mpReferenceKF) : static_cast<FrameBase*>(&mCurrentFrame);
+    KeyFrame* plastkf = brecompute_kf2kfpreint_[0] ? nullptr : mpLastKeyFrame;
+    PreIntegration<EncData>(type, mlOdomEnc, miterLastEnc, plastfb, pcurfb, plastkf);
+    plastkf = brecompute_kf2kfpreint_[1] ? nullptr : mpLastKeyFrame;
+    PreIntegration<IMUData>(type, mlOdomIMU, miterLastIMU, plastfb, pcurfb, plastkf);
+    // won't care initial value of this and how flow strategy it's (like pure vision then visualimu/mixed one)
+    for (auto& brecompute : brecompute_kf2kfpreint_) brecompute = true;
+  }
   if (type==2){
     size_t N=mpReferenceKF->GetListIMUData().size(),N2=mpReferenceKF->GetListEncData().size();
     PRINT_DEBUG_INFO_MUTEX("List size: "<<N<<" "<<N2<<endl, imu_tightly_debug_path, "debug.txt");
   }
 }
-bool Tracking::GetVelocityByEnc(bool bMapUpdated){
-  char type=1;
-//   if(bMapUpdated){// Map updated, optimize with last KeyFrame
-//     type=3;//preintegrate from LastKF to curF
-//   }
-//   else{// Map not updated, optimize with last Frame
-//     type=1;//preintegrate from LastF to curF
-//   }
+bool Tracking::GetVelocityByEnc(bool bMapUpdated) {
+  // though from kf2f won't be different when lastf is lastkf in state like bg/ba in imu,
+  // it affects reset op. in enc preint_kf
+  char type = 1;
+  // Map updated, optimize with last frame but force_reset(type==3 but plastfb!=plastkf) the one from last kf
+  if (bMapUpdated) type = 3;
   {
     unique_lock<mutex> lock(mMutexOdom);
-    PreIntegration<EncData>(type,mlOdomEnc,miterLastEnc);
+    FrameBase *plastfb, *pcurfb;
+    plastfb = static_cast<FrameBase*>(&mLastFrame);
+    pcurfb = static_cast<FrameBase*>(&mCurrentFrame);
+    bool bpreint = PreIntegration<EncData>(type, mlOdomEnc, miterLastEnc, plastfb, pcurfb, nullptr);//mpLastKeyFrame);
+/*    if (!bpreint)
+      brecompute_kf2kfpreint_[0] = true;
+    else if (type == 3)
+      brecompute_kf2kfpreint_[0] = false;*/
   }
   if (mCurrentFrame.GetEncPreInt().mdeltatij == 0) {
     return false;  // check PreIntegration() failed when mdeltatij==0, so mCurrentFrame.mTcw==cv::Mat()
@@ -406,7 +431,7 @@ void Tracking::RecomputeIMUBiasAndCurrentNavstate(){//see VIORBSLAM paper IV-E
   for(size_t i=0; i<N-1; ++i){
     unique_lock<mutex> lock(mMutexOdom);
     //so vKFInit[i].mOdomPreIntIMU is based on bg_bar=0,ba_bar=0; dbg=0 but dba/ba waits to be optimized
-    PreIntegration<IMUData>(1,mlOdomIMU,miterLastIMU,mv20pFramesReloc[i],mv20pFramesReloc[i+1]);//actually we don't need to copy the data list!
+    PreIntegration<IMUData>(1,mlOdomIMU,miterLastIMU,mv20pFramesReloc[i],mv20pFramesReloc[i+1],nullptr);//actually we don't need to copy the data list!
   }
   Vector3d bgest;
   Optimizer::OptimizeInitialGyroBias<Frame>(mv20pFramesReloc, bgest);//though JingWang uses Identity() as Info
@@ -421,7 +446,7 @@ void Tracking::RecomputeIMUBiasAndCurrentNavstate(){//see VIORBSLAM paper IV-E
   for(size_t i=0; i<N-1; ++i){
     unique_lock<mutex> lock(mMutexOdom);
     //so vKFInit[i].mOdomPreIntIMU is based on bg_bar=bgest,ba_bar=0; dbg=0 but dba/ba waits to be optimized
-    PreIntegration<IMUData>(1,mlOdomIMU,miterLastIMU,mv20pFramesReloc[i],mv20pFramesReloc[i+1]);//actually we don't need to copy the data list!
+    PreIntegration<IMUData>(1,mlOdomIMU,miterLastIMU,mv20pFramesReloc[i],mv20pFramesReloc[i+1],nullptr);//actually we don't need to copy the data list!
   }
   if (!mlOdomEnc.empty()){//we update miterLastEnc to current Frame for the next Frame's Preintegration(1/3)!
     unique_lock<mutex> lock(mMutexOdom);
@@ -431,7 +456,7 @@ void Tracking::RecomputeIMUBiasAndCurrentNavstate(){//see VIORBSLAM paper IV-E
       miterLastEnc=iter;//update miterLastEnc pointing to the nearest(now,not next time) one of this frame / begin for next frame
     else
       miterLastEnc=--iter;
-    PreIntegration<EncData>(1,mlOdomEnc,miterLastEnc,mv20pFramesReloc[N-2],mv20pFramesReloc[N-1]);
+    PreIntegration<EncData>(1,mlOdomEnc,miterLastEnc,mv20pFramesReloc[N-2],mv20pFramesReloc[N-1],nullptr);
   }
 
   // Step 3. / See VIORBSLAM paper IV-C&E: Solve C*x=D for x=[ba] (3)x1 vector
@@ -724,76 +749,70 @@ cv::Mat Tracking::GrabImageStereo(const vector<cv::Mat> &ims, const double &time
   }
 
   mCurrentFrame = Frame(mImGrays, timestamp, mpORBextractors, mpORBVocabulary, mK, mDistCoef, mbf, mThDepth,
-                        inputRect ? nullptr : &mpCameras, System::usedistort_);
+                        &preint_imu_kf_, &preint_enc_kf_, inputRect ? nullptr : &mpCameras, System::usedistort_);
 
   Track();
 
   return mCurrentFrame.GetTcwRef().clone();
 }
 
-cv::Mat Tracking::GrabImageRGBD(const cv::Mat &imRGB,const cv::Mat &imD, const double &timestamp)
-{
-    mtmGrabDelay=chrono::steady_clock::now();//zzh
-    mImGrays[0] = imRGB;
-    cv::Mat imDepth = imD;
+cv::Mat Tracking::GrabImageRGBD(const cv::Mat &imRGB,const cv::Mat &imD, const double &timestamp) {
+  mtmGrabDelay = chrono::steady_clock::now();  // zzh
+  mImGrays[0] = imRGB;
+  cv::Mat imDepth = imD;
 
-    //may be improved here!!!
-    if(mImGrays[0].channels()==3)
-    {
-        if(mbRGB)
-            cvtColor(mImGrays[0],mImGrays[0],CV_RGB2GRAY);
-        else{
-            cvtColor(mImGrays[0],mImGrays[0],CV_BGR2GRAY);
-	}
+  // may be improved here!!!
+  if (mImGrays[0].channels() == 3) {
+    if (mbRGB)
+      cvtColor(mImGrays[0], mImGrays[0], CV_RGB2GRAY);
+    else {
+      cvtColor(mImGrays[0], mImGrays[0], CV_BGR2GRAY);
     }
-    else if(mImGrays[0].channels()==4)
-    {
-        if(mbRGB)
-            cvtColor(mImGrays[0],mImGrays[0],CV_RGBA2GRAY);
-	else
-            cvtColor(mImGrays[0],mImGrays[0],CV_BGRA2GRAY);
-    }
+  } else if (mImGrays[0].channels() == 4) {
+    if (mbRGB)
+      cvtColor(mImGrays[0], mImGrays[0], CV_RGBA2GRAY);
+    else
+      cvtColor(mImGrays[0], mImGrays[0], CV_BGRA2GRAY);
+  }
 
-    if((fabs(mDepthMapFactor-1.0f)>1e-5) || imDepth.type()!=CV_32F)
-        imDepth.convertTo(imDepth,CV_32F,mDepthMapFactor);
+  if ((fabs(mDepthMapFactor - 1.0f) > 1e-5) || imDepth.type() != CV_32F)
+    imDepth.convertTo(imDepth, CV_32F, mDepthMapFactor);
 
-    mCurrentFrame = Frame(mImGrays[0],imDepth,timestamp,mpORBextractors[0],mpORBVocabulary,mK,mDistCoef,mbf,mThDepth);//here extracting the ORB features of ImGray
+  mCurrentFrame = Frame(mImGrays[0], imDepth, timestamp, mpORBextractors[0], mpORBVocabulary, mK, mDistCoef, mbf,
+                        mThDepth, &preint_imu_kf_, &preint_enc_kf_);  // here extracting the ORB features of ImGray
 
-    cv::Mat img[2]={imRGB.clone(),imD.clone()};
-    Track(img);
+  cv::Mat img[2] = {imRGB.clone(), imD.clone()};
+  Track(img);
 
-    return mCurrentFrame.GetTcwRef().clone();
+  return mCurrentFrame.GetTcwRef().clone();
 }
 
+cv::Mat Tracking::GrabImageMonocular(const cv::Mat &im, const double &timestamp) {
+  mtmGrabDelay = chrono::steady_clock::now();  // zzh
+  mImGrays[0] = im;
 
-cv::Mat Tracking::GrabImageMonocular(const cv::Mat &im, const double &timestamp)
-{
-    mtmGrabDelay=chrono::steady_clock::now();//zzh
-    mImGrays[0] = im;
-
-    if(mImGrays[0].channels()==3)
-    {
-        if(mbRGB)
-            cvtColor(mImGrays[0],mImGrays[0],CV_RGB2GRAY);
-        else
-            cvtColor(mImGrays[0],mImGrays[0],CV_BGR2GRAY);
-    }
-    else if(mImGrays[0].channels()==4)
-    {
-        if(mbRGB)
-            cvtColor(mImGrays[0],mImGrays[0],CV_RGBA2GRAY);
-        else
-            cvtColor(mImGrays[0],mImGrays[0],CV_BGRA2GRAY);
-    }
-
-    if(mState==NOT_INITIALIZED || mState==NO_IMAGES_YET)
-        mCurrentFrame = Frame(mImGrays[0],timestamp,mpIniORBextractor,mpORBVocabulary,mK,mDistCoef,mbf,mThDepth);
+  if (mImGrays[0].channels() == 3) {
+    if (mbRGB)
+      cvtColor(mImGrays[0], mImGrays[0], CV_RGB2GRAY);
     else
-        mCurrentFrame = Frame(mImGrays[0],timestamp,mpORBextractors[0],mpORBVocabulary,mK,mDistCoef,mbf,mThDepth);
+      cvtColor(mImGrays[0], mImGrays[0], CV_BGR2GRAY);
+  } else if (mImGrays[0].channels() == 4) {
+    if (mbRGB)
+      cvtColor(mImGrays[0], mImGrays[0], CV_RGBA2GRAY);
+    else
+      cvtColor(mImGrays[0], mImGrays[0], CV_BGRA2GRAY);
+  }
 
-    Track();
+  if (mState == NOT_INITIALIZED || mState == NO_IMAGES_YET)
+    mCurrentFrame = Frame(mImGrays[0], timestamp, mpIniORBextractor, mpORBVocabulary, mK, mDistCoef, mbf, mThDepth,
+                          &preint_imu_kf_, &preint_enc_kf_);
+  else
+    mCurrentFrame = Frame(mImGrays[0], timestamp, mpORBextractors[0], mpORBVocabulary, mK, mDistCoef, mbf, mThDepth,
+                          &preint_imu_kf_, &preint_enc_kf_);
 
-    return mCurrentFrame.GetTcwRef().clone();
+  Track();
+
+  return mCurrentFrame.GetTcwRef().clone();
 }
 
 void Tracking::Track(cv::Mat img[2])//changed a lot by zzh inspired by JingWang
@@ -885,7 +904,7 @@ void Tracking::Track(cv::Mat img[2])//changed a lot by zzh inspired by JingWang
                         }
                     }
                 }else{
-                    if (!mLastFrame.GetTcwRef().empty()) GetVelocityByEnc();//try to utilize the Encoder's data
+                    if (!mLastFrame.GetTcwRef().empty()) GetVelocityByEnc(bMapUpdated);//try to utilize the Encoder's data
                     else cout<<redSTR<<"LastFrame has no Tcw!"<<whiteSTR<<endl;
                     if(mVelocity.empty()){// || mCurrentFrame.mnId<mnLastRelocFrameId+2){//if last frame relocalized, there's no motion could be calculated, so I think 2nd condition is useless
 //                        if (!mVelocity.empty()) cerr<<redSTR"Error in Velocity.empty()!!!"<<endl;//check if right
@@ -925,7 +944,7 @@ void Tracking::Track(cv::Mat img[2])//changed a lot by zzh inspired by JingWang
                 cout<<redSTR<<"Entering Wrong Tracking Mode With VIO/VIEO, Please Check!"<<endl;
                 assert(0);
             }else{
-                if (!mLastFrame.GetTcwRef().empty()) GetVelocityByEnc();//try to utilize the Encoder's data
+                if (!mLastFrame.GetTcwRef().empty()) GetVelocityByEnc(bMapUpdated);//try to utilize the Encoder's data
                 else cout<<redSTR<<"LastFrame has no Tcw!"<<whiteSTR<<endl;
                 if(!mbVO)
                 {
@@ -1041,6 +1060,9 @@ void Tracking::Track(cv::Mat img[2])//changed a lot by zzh inspired by JingWang
             if (mCurrentFrame.GetEncPreInt().mdeltatij>0){//though it may introduce error, it ensure the completeness of the Map
                 TrackWithOnlyOdom(bMapUpdated);
             }else{
+              // for when enc ok, always OK/ODOMOK, no mbRelocBiasPrepare entered for no relocalization is called or
+              // always Preintegration(1/3) before, but when enc failed we need to preint kf2kf next relocalization time
+              for (auto& brecompute : brecompute_kf2kfpreint_) brecompute = true;
                 // Clear Frame vectors for reloc bias computation
                 if(mv20pFramesReloc.size()>0){
                     for (int i=0;i<mv20pFramesReloc.size();++i) delete mv20pFramesReloc[i];


### PR DESCRIPTION
0.fix cvMat multithread bug + extract mNavState & mOdomPreInt to FrameBase
1.average kf2kf preintegration time to each
f2f preintegration in normal situation
2.but if kf2f preint failed at some frame,
kf2kf preintegration will still be called
3.speed up kf set bad flag when connect 2 imu lists