### PR TITLE
FIX: fix EncPreIntegrator for kf2f average patch

### DIFF
--- a/Thirdparty/DBoW2/CMakeLists.txt
+++ b/Thirdparty/DBoW2/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 project(DBoW2)
 
 set(USE_G2O_NEWEST 0)
-set(USE_OPENCV_NEWEST 0)
+set(USE_OPENCV_NEWEST 1)
 
 MESSAGE("Build type: " ${CMAKE_BUILD_TYPE})
 


### PR DESCRIPTION
    1.fix copy and operator= constructor bug in
    EncPreIntegrator
    2.use opencv 4.5 for DBoW2 lib, which doesn't
    affect accuracy

TEST: passed on our datasets, unit cm
Corridor15_200 VIEOS2 2.8, VEOS2 3.6
Lab15_200 VIEOS2 2.3, VEOS2 3.1