### PR TITLE
FIX: fix kf2kf average bug

### DIFF
--- a/include/Frame.h
+++ b/include/Frame.h
@@ -75,14 +75,15 @@ class Frame : public FrameBase {
   //[iteri,iterj) IMU preintegration, breset=false could make KF2KF preintegration time averaged to per frame &&
   // connect 2KFs preintegration by only preintegrating the final KF2KF period
   template <class OdomData>
-  int PreIntegrationFromLastKF(FrameBase *plastkf, const typename aligned_list<OdomData>::const_iterator &iteri,
+  int PreIntegrationFromLastKF(FrameBase *plastkf, FrameBase *plastfb_kf,
+                               const typename aligned_list<OdomData>::const_iterator &iteri,
                                const typename aligned_list<OdomData>::const_iterator &iterj, bool breset = false,
                                int8_t verbose = 0) {
     CV_Assert(ppreint_enc_kf_);
     NavState ns = plastkf->GetNavState();
     auto iterj_1 = iterj;
     --iterj_1;
-    return FrameBase::PreIntegration<OdomData>(breset ? plastkf->mTimeStamp : (*iteri).mtm, (*iterj_1).mtm, ns.mbg,
+    return FrameBase::PreIntegration<OdomData>(breset ? plastfb_kf->mTimeStamp : (*iteri).mtm, (*iterj_1).mtm, ns.mbg,
                                                ns.mba, iteri, iterj, breset, ppreint_enc_kf_, verbose);
   }
 
@@ -282,7 +283,7 @@ class Frame : public FrameBase {
 template <>
 void Frame::DeepMovePreintOdomFromLastKF(IMUPreintegrator &preint_odom);
 template <>
-int Frame::PreIntegrationFromLastKF<IMUData>(FrameBase *plastkf,
+int Frame::PreIntegrationFromLastKF<IMUData>(FrameBase *plastkf, FrameBase *plastfb_kf,
                                              const typename aligned_list<IMUData>::const_iterator &iteri,
                                              const typename aligned_list<IMUData>::const_iterator &iterj, bool breset,
                                              int8_t verbose);

--- a/include/Tracking.h
+++ b/include/Tracking.h
@@ -1,53 +1,51 @@
 /**
-* This file is part of ORB-SLAM2.
-*
-* Copyright (C) 2014-2016 Raúl Mur-Artal <raulmur at unizar dot es> (University of Zaragoza)
-* For more information see <https://github.com/leavesnight/VIEO_SLAM>
-*
-* ORB-SLAM2 is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* ORB-SLAM2 is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
-*/
-
+ * This file is part of ORB-SLAM2.
+ *
+ * Copyright (C) 2014-2016 Raúl Mur-Artal <raulmur at unizar dot es> (University of Zaragoza)
+ * For more information see <https://github.com/leavesnight/VIEO_SLAM>
+ *
+ * ORB-SLAM2 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ORB-SLAM2 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifndef TRACKING_H
 #define TRACKING_H
 
 #include "OdomData.h"
-#include<chrono>//for delay control
+#include <chrono>  //for delay control
 
-//created by zzh over.
+// created by zzh over.
 
-#include<opencv2/core/core.hpp>
-#include<opencv2/features2d/features2d.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/features2d/features2d.hpp>
 
-#include"Viewer.h"
-#include"FrameDrawer.h"
-#include"Map.h"
-#include"LocalMapping.h"
-#include"LoopClosing.h"
-#include"Frame.h"
+#include "Viewer.h"
+#include "FrameDrawer.h"
+#include "Map.h"
+#include "LocalMapping.h"
+#include "LoopClosing.h"
+#include "Frame.h"
 #include "ORBVocabulary.h"
-#include"KeyFrameDatabase.h"
-#include"ORBextractor.h"
+#include "KeyFrameDatabase.h"
+#include "ORBextractor.h"
 #include "Initializer.h"
 #include "MapDrawer.h"
 #include "System.h"
 
 #include <mutex>
 
-namespace VIEO_SLAM
-{
-class IMUInitialization;//zzh, for they includes each other
+namespace VIEO_SLAM {
+class IMUInitialization;  // zzh, for they includes each other
 
 class Viewer;
 class FrameDrawer;
@@ -57,19 +55,20 @@ class LoopClosing;
 class System;
 class GeometricCamera;
 
-class Tracking
-{
+class Tracking {
  public:
   template <class T>
   using aligned_list = IMUPreintegrator::aligned_list<T>;
+
  private:
-  //Created by zzh
-  //pure encoder edges
+  // Created by zzh
+  // pure encoder edges
   void TrackWithOnlyOdom(bool bMapUpdated);
   // Odom PreIntegration
-  template<class OdomData>
-  inline bool iterijFind(const listeig(OdomData) &lodom_data,const double &cur_time,
-			 typename listeig(OdomData)::const_iterator &iter,const double&err_odomimg,bool bSearchBack=true);
+  template <class OdomData>
+  inline bool iterijFind(const listeig(OdomData) & lodom_data, const double &cur_time,
+                         typename listeig(OdomData)::const_iterator &iter, const double &err_odomimg,
+                         bool bSearchBack = true);
   /* KeyFrame *plastKF: timestamp_/imu preintegration start KF, can be NULL when type=0
    * KeyFrame *pcurKF: &imu preintegration end/storing KF
    * type: 0 for initialize, 1 for inter-Frame PreInt., 2 for inter-KF PreInt.
@@ -79,319 +78,336 @@ class Tracking
    * we also reserved last left one in 2 lists(especially for Enc);
    * if pLastF & pCurF exit, we use them instead of mLastFrame & mCurrentFrame
    */
-  template<class OdomData>
+  template <class OdomData>
   bool PreIntegration(const int8_t type, Eigen::aligned_list<OdomData> &lodom_data,
-                      typename Eigen::aligned_list<OdomData>::const_iterator &iter_lastodom,
-                      FrameBase *plastfb, FrameBase *pcurfb, KeyFrame *plastkf, int8_t verbose = 0);
-  void PreIntegration(const int8_t type=0);
-  bool TrackWithIMU(bool bMapUpdated);//use IMU prediction instead of constant velocity/uniform motion model
+                      typename Eigen::aligned_list<OdomData>::const_iterator &iter_lastodom, FrameBase *plastfb,
+                      FrameBase *pcurfb, KeyFrame *plastkf, FrameBase *plastfb_kf = nullptr, bool breset_intkf = false,
+                      int8_t verbose = 0);
+  void PreIntegration(const int8_t type = 0);
+  bool TrackWithIMU(bool bMapUpdated);  // use IMU prediction instead of constant velocity/uniform motion model
   // Predict the NavState of Current Frame by IMU
-  bool PredictNavStateByIMU(bool bMapUpdated);//use IMU motion model, like motion update/prediction in ekf, if prediction failed(e.g. no imu data) then false
-  //IMUPreintegrator GetIMUPreIntSinceLastKF();
-  bool TrackLocalMapWithIMU(bool bMapUpdated);//track local map with IMU motion-only BA, if no imu data it degenerates to TrackLocalMap()
-  void RecomputeIMUBiasAndCurrentNavstate();//recompute bias && mCurrentFrame.mNavState when 19th Frame after reloc.
+  bool PredictNavStateByIMU(bool bMapUpdated);  // use IMU motion model, like motion update/prediction in ekf, if
+                                                // prediction failed(e.g. no imu data) then false
+  // IMUPreintegrator GetIMUPreIntSinceLastKF();
+  bool TrackLocalMapWithIMU(
+      bool bMapUpdated);  // track local map with IMU motion-only BA, if no imu data it degenerates to TrackLocalMap()
+  void RecomputeIMUBiasAndCurrentNavstate();  // recompute bias && mCurrentFrame.mNavState when 19th Frame after reloc.
 
   // Get mVelocity by Encoder data
   bool GetVelocityByEnc(bool bMapUpdated);
 
   // Flags for relocalization. Create new KF once bias re-computed & flag for preparation for bias re-compute
-  bool mbRelocBiasPrepare;//true means preparing/not prepared
+  bool mbRelocBiasPrepare;  // true means preparing/not prepared
   // 20 Frames are used to compute bias
-  vector<Frame*> mv20pFramesReloc;//vector<Frame,Eigen::aligned_allocator<Frame> > mv20FramesReloc used by JW, notice why we must use Eigen::aligned_allocator(quaterniond in NavState, or Segementation fault)
+  vector<Frame *>
+      mv20pFramesReloc;  // vector<Frame,Eigen::aligned_allocator<Frame> > mv20FramesReloc used by JW, notice why we
+                         // must use Eigen::aligned_allocator(quaterniond in NavState, or Segementation fault)
 
-  //Consts
-  //Error allow between "simultaneous" IMU data(Timu) & Image's mTimeStamp(Timg): Timu=[Timg-err,Timg+err]
+  // Consts
+  // Error allow between "simultaneous" IMU data(Timu) & Image's mTimeStamp(Timg): Timu=[Timg-err,Timg+err]
   double mdErrIMUImg;
-  //Tbc,Tbo
-  cv::Mat mTbc,mTce;//Tbc is from IMU frame to camera frame;Tbo is from IMU frame to encoder frame(the centre of 2 driving wheels, +x pointing to forward,+z pointing up)
-  //delay time of Odom Data received(CacheOdom) relative to the Image entering(GrabImageX), or Camera.delayForPolling
+  // Tbc,Tbo
+  cv::Mat mTbc, mTce;  // Tbc is from IMU frame to camera frame;Tbo is from IMU frame to encoder frame(the centre of 2
+                       // driving wheels, +x pointing to forward,+z pointing up)
+  // delay time of Odom Data received(CacheOdom) relative to the Image entering(GrabImageX), or Camera.delayForPolling
   double mDelayCache;
-  //delay time of the image's timestamp to odom's timestamp, or delaytoimu, delaytoenc: Timg=Todom+mDelayToOdom
-  double mDelayToIMU,mDelayToEnc;
-  //Variables
-  std::chrono::steady_clock::time_point mtmGrabDelay;//for delay control(we found our Enc&IMU's response has some delay=20ms)
-  //cache queue for vl,vr/IMU & its own timestamp from LastKF
+  // delay time of the image's timestamp to odom's timestamp, or delaytoimu, delaytoenc: Timg=Todom+mDelayToOdom
+  double mDelayToIMU, mDelayToEnc;
+  // Variables
+  std::chrono::steady_clock::time_point
+      mtmGrabDelay;  // for delay control(we found our Enc&IMU's response has some delay=20ms)
+  // cache queue for vl,vr/IMU & its own timestamp from LastKF
   listeig(EncData) mlOdomEnc;
   listeig(IMUData) mlOdomIMU;
-  std::mutex mMutexOdom;//for 2 lists' multithreads' operation
-  listeig(EncData)::const_iterator miterLastEnc;//Last EncData pointer in LastFrame, need to check its tm and some data latter to find the min|mtmSyncOdom-tm| s.t. tm<=mtmSyncOdom
-  listeig(IMUData)::const_iterator miterLastIMU;//Last IMUData pointer in LastFrame, we don't change the OdomData's content
+  std::mutex mMutexOdom;                          // for 2 lists' multithreads' operation
+  listeig(EncData)::const_iterator miterLastEnc;  // Last EncData pointer in LastFrame, need to check its tm and some
+                                                  // data latter to find the min|mtmSyncOdom-tm| s.t. tm<=mtmSyncOdom
+  listeig(IMUData)::const_iterator
+      miterLastIMU;  // Last IMUData pointer in LastFrame, we don't change the OdomData's content
   bool brecompute_kf2kfpreint_[2];
+  bool blast_kf2kfpreint_;
 
   unsigned long mnLastOdomKFId;
 
-public:
-  //Add Odom(Enc/IMU) data to cache queue
-  cv::Mat CacheOdom(const double &timestamp, const double* odomdata, const char mode);
+ public:
+  // Add Odom(Enc/IMU) data to cache queue
+  cv::Mat CacheOdom(const double &timestamp, const double *odomdata, const char mode);
 
-  void SetLastKeyFrame(KeyFrame* pKF){
-    mpLastKeyFrame=pKF;
-  }
-  void SetReferenceKF(KeyFrame* pKF){
-    mpReferenceKF=pKF;
-  }
+  void SetLastKeyFrame(KeyFrame *pKF) { mpLastKeyFrame = pKF; }
+  void SetReferenceKF(KeyFrame *pKF) { mpReferenceKF = pKF; }
 
-   //for ros_mono_pub.cc
+  // for ros_mono_pub.cc
   bool mbKeyFrameCreated;
-  cv::Mat GetKeyFramePose(){
-    return mpReferenceKF->GetPose();
-  }
+  cv::Mat GetKeyFramePose() { return mpReferenceKF->GetPose(); }
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-//created by zzh over.
+  // created by zzh over.
 
-public:
-    Tracking(System* pSys, ORBVocabulary* pVoc, FrameDrawer* pFrameDrawer, MapDrawer* pMapDrawer, Map* pMap,
-             KeyFrameDatabase* pKFDB, const string &strSettingPath, const int sensor);
-    ~Tracking() {
-      for (auto& pcam : mpCameras) {
-        delete pcam;
-      }
+ public:
+  Tracking(System *pSys, ORBVocabulary *pVoc, FrameDrawer *pFrameDrawer, MapDrawer *pMapDrawer, Map *pMap,
+           KeyFrameDatabase *pKFDB, const string &strSettingPath, const int sensor);
+  ~Tracking() {
+    for (auto &pcam : mpCameras) {
+      delete pcam;
     }
+  }
 
-    // Preprocess the input and call Track(). Extract features and performs stereo matching.
-    cv::Mat GrabImageStereo(const vector<cv::Mat> &ims, const double &timestamp, const bool inputRect = true);
-    cv::Mat GrabImageRGBD(const cv::Mat &imRGB,const cv::Mat &imD, const double &timestamp);
-    cv::Mat GrabImageMonocular(const cv::Mat &im, const double &timestamp);
+  // Preprocess the input and call Track(). Extract features and performs stereo matching.
+  cv::Mat GrabImageStereo(const vector<cv::Mat> &ims, const double &timestamp, const bool inputRect = true);
+  cv::Mat GrabImageRGBD(const cv::Mat &imRGB, const cv::Mat &imD, const double &timestamp);
+  cv::Mat GrabImageMonocular(const cv::Mat &im, const double &timestamp);
 
-    void SetLocalMapper(LocalMapping* pLocalMapper);
-    void SetLoopClosing(LoopClosing* pLoopClosing);
-    void SetIMUInitiator(IMUInitialization *pIMUInitiator){mpIMUInitiator=pIMUInitiator;}//zzh
-    void SetViewer(Viewer* pViewer);
+  void SetLocalMapper(LocalMapping *pLocalMapper);
+  void SetLoopClosing(LoopClosing *pLoopClosing);
+  void SetIMUInitiator(IMUInitialization *pIMUInitiator) { mpIMUInitiator = pIMUInitiator; }  // zzh
+  void SetViewer(Viewer *pViewer);
 
-    // Load new settings
-    // The focal lenght should be similar or scale prediction will fail when projecting points
-    // TODO: Modify MapPoint::PredictScale to take into account focal lenght
+  // Load new settings
+  // The focal lenght should be similar or scale prediction will fail when projecting points
+  // TODO: Modify MapPoint::PredictScale to take into account focal lenght
 
-    // Use this function if you have deactivated local mapping and you only want to localize the camera.
-    void InformOnlyTracking(const bool &flag);
+  // Use this function if you have deactivated local mapping and you only want to localize the camera.
+  void InformOnlyTracking(const bool &flag);
 
-public:
-    // Tracking states
-    enum eTrackingState{
-        SYSTEM_NOT_READY=-1,//used by FrameDrawer, not Tracking
-        NO_IMAGES_YET=0,
-        NOT_INITIALIZED=1,
-        OK=2,
-        LOST=3,
-        ODOMOK=4,//added by zzh
-	MAP_REUSE=5,//added by zzh
-	MAP_REUSE_RELOC=6//added by zzh
-    };
+ public:
+  // Tracking states
+  enum eTrackingState {
+    SYSTEM_NOT_READY = -1,  // used by FrameDrawer, not Tracking
+    NO_IMAGES_YET = 0,
+    NOT_INITIALIZED = 1,
+    OK = 2,
+    LOST = 3,
+    ODOMOK = 4,          // added by zzh
+    MAP_REUSE = 5,       // added by zzh
+    MAP_REUSE_RELOC = 6  // added by zzh
+  };
 
-    eTrackingState mState;
-    eTrackingState mLastProcessedState;
+  eTrackingState mState;
+  eTrackingState mLastProcessedState;
 
-    // Input sensor
-    int mSensor;//value's type is VIEO_SLAM::System::eSensor
+  // Input sensor
+  int mSensor;  // value's type is VIEO_SLAM::System::eSensor
 
-    // Current Frame
-    EncPreIntegrator preint_enc_kf_;
-    IMUPreintegrator preint_imu_kf_;
-    Frame mCurrentFrame;
-    vector<cv::Mat> mImGrays = vector<cv::Mat>(1);//used by FrameDrawer
+  // Current Frame
+  EncPreIntegrator preint_enc_kf_;
+  IMUPreintegrator preint_imu_kf_;
+  Frame mCurrentFrame;
+  vector<cv::Mat> mImGrays = vector<cv::Mat>(1);  // used by FrameDrawer
 
-    // Initialization Variables (Monocular)
-    std::vector<int> mvIniLastMatches;
-    std::vector<int> mvIniMatches;
-    std::vector<cv::Point2f> mvbPrevMatched;
-    std::vector<cv::Point3f> mvIniP3D;
-    Frame mInitialFrame;
+  // Initialization Variables (Monocular)
+  std::vector<int> mvIniLastMatches;
+  std::vector<int> mvIniMatches;
+  std::vector<cv::Point2f> mvbPrevMatched;
+  std::vector<cv::Point3f> mvIniP3D;
+  Frame mInitialFrame;
 
-    // Lists used to recover the full camera trajectory at the end of the execution.
-    // Basically we store the reference keyframe for each frame and its relative transformation
-    list<cv::Mat> mlRelativeFramePoses;
-    list<Vector3d> relative_frame_bvwbs_;
-    list<KeyFrame*> mlpReferences;
-    list<double> mlFrameTimes;
-    list<bool> mlbLost;//true for lost!
+  // Lists used to recover the full camera trajectory at the end of the execution.
+  // Basically we store the reference keyframe for each frame and its relative transformation
+  list<cv::Mat> mlRelativeFramePoses;
+  list<Vector3d> relative_frame_bvwbs_;
+  list<KeyFrame *> mlpReferences;
+  list<double> mlFrameTimes;
+  list<bool> mlbLost;  // true for lost!
 
-    // True if local mapping is deactivated and we are performing only localization
-    bool mbOnlyTracking;
+  // True if local mapping is deactivated and we are performing only localization
+  bool mbOnlyTracking;
 
-    void Reset();
+  void Reset();
 
-protected:
-    // Main tracking function. It is independent of the input sensor.
-    void Track(cv::Mat img[2]=NULL);//img[2] recorded by KFs
+ protected:
+  // Main tracking function. It is independent of the input sensor.
+  void Track(cv::Mat img[2] = NULL);  // img[2] recorded by KFs
 
-    // Map initialization for stereo and RGB-D
-    void StereoInitialization(cv::Mat img[2]=NULL);
+  // Map initialization for stereo and RGB-D
+  void StereoInitialization(cv::Mat img[2] = NULL);
 
-    // Map initialization for monocular
-    void MonocularInitialization();
-    void CreateInitialMapMonocular();
+  // Map initialization for monocular
+  void MonocularInitialization();
+  void CreateInitialMapMonocular();
 
-    void CheckReplacedInLastFrame();
-    bool TrackReferenceKeyFrame(int thInMPs=10,int thMatch=15);//track mCurrentFrame with mpReferenceKF by SBB and motion-only BA(if nmatches is enough), then \
+  void CheckReplacedInLastFrame();
+  bool TrackReferenceKeyFrame(
+      int thInMPs = 10,
+      int thMatch =
+          15);  //track mCurrentFrame with mpReferenceKF by SBB and motion-only BA(if nmatches is enough), then \
     discard outliers, return nInliers>=10
-    void UpdateLastFrame();//update last Frame's Pose by reference KeyFrame&&mlRelativeFramePoses for nonlocalization mode
-    bool TrackWithMotionModel();//UpdateLastFrame, use SBP to get mCurrentFrame.mvpMapPoints, then motion-only BA(if nmatches is enough), \
+  void
+  UpdateLastFrame();  // update last Frame's Pose by reference KeyFrame&&mlRelativeFramePoses for nonlocalization mode
+  bool
+  TrackWithMotionModel();  //UpdateLastFrame, use SBP to get mCurrentFrame.mvpMapPoints, then motion-only BA(if nmatches is enough), \
     discard outliers, return nInliers>=10 for nonlocalization mode
 
-    bool Relocalization();
+  bool Relocalization();
 
-    void UpdateLocalMap();//mpMap->SetReferenceMapPoints(mvpLocalMapPoints), UpdateLocalKeyFrames&&UpdateLocalPoints
-    void UpdateLocalPoints();//use mvpLocalKeyFrames[i]->mvpMapPoints to fill mvpLocalMapPoints(avoid duplications by pMP->mnTrackReferenceForFrame)
-    void UpdateLocalKeyFrames();//use mCurrentFrame&&its covisible KFs(>=1 covisible MP)&&the KFs' neighbors(10 best covisibility KFs&&parent&&children) \
+  void UpdateLocalMap();     // mpMap->SetReferenceMapPoints(mvpLocalMapPoints), UpdateLocalKeyFrames&&UpdateLocalPoints
+  void UpdateLocalPoints();  // use mvpLocalKeyFrames[i]->mvpMapPoints to fill mvpLocalMapPoints(avoid duplications by
+                             // pMP->mnTrackReferenceForFrame)
+  void
+  UpdateLocalKeyFrames();  //use mCurrentFrame&&its covisible KFs(>=1 covisible MP)&&the KFs' neighbors(10 best covisibility KFs&&parent&&children) \
     to make mvpLocalKeyFrames, update (mCurrentFrame.)mpReferenceKF to max covisible KF
 
-    bool TrackLocalMap();//use UpdateLocalMap&&SearchLocalPoints(mvpLocalMapPoints) to add new matched \
+  bool TrackLocalMap();  //use UpdateLocalMap&&SearchLocalPoints(mvpLocalMapPoints) to add new matched \
     mvpMapPoints in mCurrentFrame, then motion-only BA to add Pose's accuracy and update mnMatchesInliers&&pMP->mnFound, \
     finally may judge mnMatchesInliers to one ballot veto the mState to make it Lost
-    void SearchLocalPoints();//update mCurrentFrame->mvpMapPoints(also discard bad ones)+mvpLocalMapPoints' pMP->mnVisible&&mnLastFrameSeen and \
+  void
+  SearchLocalPoints();  //update mCurrentFrame->mvpMapPoints(also discard bad ones)+mvpLocalMapPoints' pMP->mnVisible&&mnLastFrameSeen and \
     call mCurrentFrame.isInFrustum(pMP,0.5), then try to match mvpLocalMapPoints to mCurrentFrame by SBP()(add some mvpMapPoints)
 
-    bool NeedNewKeyFrame();
-    void CreateNewKeyFrame(cv::Mat img[2]=NULL);
+  bool NeedNewKeyFrame();
+  void CreateNewKeyFrame(cv::Mat img[2] = NULL);
 
-    // In case of performing only localization, this flag is true when there are no matches to
-    // points in the map. Still tracking will continue if there are enough matches with temporal points.
-    // In that case we are doing visual odometry. The system will try to do relocalization to recover
-    // "zero-drift" localization to the map.
-    bool mbVO;
+  // In case of performing only localization, this flag is true when there are no matches to
+  // points in the map. Still tracking will continue if there are enough matches with temporal points.
+  // In that case we are doing visual odometry. The system will try to do relocalization to recover
+  // "zero-drift" localization to the map.
+  bool mbVO;
 
-    //Other Thread Pointers
-    LocalMapping* mpLocalMapper;
-    LoopClosing* mpLoopClosing;
-    IMUInitialization* mpIMUInitiator;//zzh
+  // Other Thread Pointers
+  LocalMapping *mpLocalMapper;
+  LoopClosing *mpLoopClosing;
+  IMUInitialization *mpIMUInitiator;  // zzh
 
-    //ORB
-    vector<ORBextractor*> mpORBextractors = vector<ORBextractor*>(1, nullptr);
-    ORBextractor* mpIniORBextractor;
+  // ORB
+  vector<ORBextractor *> mpORBextractors = vector<ORBextractor *>(1, nullptr);
+  ORBextractor *mpIniORBextractor;
 
-    //BoW
-    ORBVocabulary* mpORBVocabulary;
-    KeyFrameDatabase* mpKeyFrameDB;
+  // BoW
+  ORBVocabulary *mpORBVocabulary;
+  KeyFrameDatabase *mpKeyFrameDB;
 
-    // Initalization (only for monocular)
-    Initializer* mpInitializer;
+  // Initalization (only for monocular)
+  Initializer *mpInitializer;
 
-    //Local Map
-    KeyFrame* mpReferenceKF;//corresponding to mCurrentFrame(most of time ==mCurrentFrame.mpReferenceKF)
-    std::vector<KeyFrame*> mvpLocalKeyFrames;
-    std::vector<MapPoint*> mvpLocalMapPoints;
+  // Local Map
+  KeyFrame *mpReferenceKF;  // corresponding to mCurrentFrame(most of time ==mCurrentFrame.mpReferenceKF)
+  std::vector<KeyFrame *> mvpLocalKeyFrames;
+  std::vector<MapPoint *> mvpLocalMapPoints;
 
-    // System
-    System* mpSystem;
+  // System
+  System *mpSystem;
 
-    //Drawers
-    Viewer* mpViewer;
-    FrameDrawer* mpFrameDrawer;
-    MapDrawer* mpMapDrawer;
+  // Drawers
+  Viewer *mpViewer;
+  FrameDrawer *mpFrameDrawer;
+  MapDrawer *mpMapDrawer;
 
-    //Map
-    Map* mpMap;
+  // Map
+  Map *mpMap;
 
-    //Calibration matrix
-    cv::Mat mK;
-    cv::Mat mDistCoef;
-    float mbf;
-    vector<GeometricCamera*> mpCameras;
+  // Calibration matrix
+  cv::Mat mK;
+  cv::Mat mDistCoef;
+  float mbf;
+  vector<GeometricCamera *> mpCameras;
 
-    //New KeyFrame rules (according to fps)
-    int mMinFrames;
-    int mMaxFrames;
+  // New KeyFrame rules (according to fps)
+  int mMinFrames;
+  int mMaxFrames;
 
-    // Threshold close/far points
-    // Points seen as close by the stereo/RGBD sensor are considered reliable
-    // and inserted from just one frame. Far points requiere a match in two keyframes.
-    float mThDepth;//40b, here TUM use 3.2(m)
+  // Threshold close/far points
+  // Points seen as close by the stereo/RGBD sensor are considered reliable
+  // and inserted from just one frame. Far points requiere a match in two keyframes.
+  float mThDepth;  // 40b, here TUM use 3.2(m)
 
-    // For RGB-D inputs only. For some datasets (e.g. TUM) the depthmap values are scaled.
-    float mDepthMapFactor;
+  // For RGB-D inputs only. For some datasets (e.g. TUM) the depthmap values are scaled.
+  float mDepthMapFactor;
 
-    //Current matches in frame
-    int mnMatchesInliers;//rectified in TrackLocalMap()
+  // Current matches in frame
+  int mnMatchesInliers;  // rectified in TrackLocalMap()
 
-    //Last Frame, KeyFrame and Relocalisation Info
-    KeyFrame* mpLastKeyFrame;
-    Frame mLastFrame;
-    unsigned int mnLastKeyFrameId;
-    unsigned int mnLastRelocFrameId;
+  // Last Frame, KeyFrame and Relocalisation Info
+  KeyFrame *mpLastKeyFrame;
+  Frame mLastFrame;
+  unsigned int mnLastKeyFrameId;
+  unsigned int mnLastRelocFrameId;
 
-    //Motion Model
-    cv::Mat mVelocity;
+  // Motion Model
+  cv::Mat mVelocity;
 
-    //Color order (true RGB, false BGR, ignored if grayscale)
-    bool mbRGB;
+  // Color order (true RGB, false BGR, ignored if grayscale)
+  bool mbRGB;
 
-    list<MapPoint*> mlpTemporalPoints;
+  list<MapPoint *> mlpTemporalPoints;
 };
 
-//created by zzh
-template<class EncData>
-bool Tracking::iterijFind(const listeig(EncData) &mlOdomEnc,const double &cur_time,
-			  typename listeig(EncData)::const_iterator &iter,const double&err_odomimg,bool bSearchBack){
-  typename listeig(EncData)::const_iterator iter1;//iter-1 or iter+1
-  double minErr;//=err_odomimg+1;
-  if (bSearchBack){//should==mlOdomEnc.end()
-    while (iter!=mlOdomEnc.begin()){//begin is min >= lastKFTime-err
-      if ((--iter)->mtm<=cur_time) break;//get max <= cur_time+0
+// created by zzh
+template <class EncData>
+bool Tracking::iterijFind(const listeig(EncData) & mlOdomEnc, const double &cur_time,
+                          typename listeig(EncData)::const_iterator &iter, const double &err_odomimg,
+                          bool bSearchBack) {
+  typename listeig(EncData)::const_iterator iter1;  // iter-1 or iter+1
+  double minErr;                                    //=err_odomimg+1;
+  if (bSearchBack) {                                // should==mlOdomEnc.end()
+    while (iter != mlOdomEnc.begin()) {             // begin is min >= lastKFTime-err
+      if ((--iter)->mtm <= cur_time) break;         // get max <= cur_time+0
     }
-    //Notice mlOdomEnc.empty()==false!
-//     if (iter!=mlOdomEnc.end()){//find a nearest iter to cur_time
-      if (cur_time>iter->mtm){//iter==begin may still have iter->mtm>cur_time
-        minErr=cur_time-iter->mtm;
-        iter1=iter;++iter1;//iter+1
-        if (iter1!=mlOdomEnc.end()&&(iter1->mtm-cur_time<minErr)){
-          iter=iter1;
-          minErr=iter1->mtm-cur_time;
-        }
-      }else{//we don't need to compare anything when iter->mtm>=cur_time
-	    minErr=iter->mtm-cur_time;
+    // Notice mlOdomEnc.empty()==false!
+    //     if (iter!=mlOdomEnc.end()){//find a nearest iter to cur_time
+    if (cur_time > iter->mtm) {  // iter==begin may still have iter->mtm>cur_time
+      minErr = cur_time - iter->mtm;
+      iter1 = iter;
+      ++iter1;  // iter+1
+      if (iter1 != mlOdomEnc.end() && (iter1->mtm - cur_time < minErr)) {
+        iter = iter1;
+        minErr = iter1->mtm - cur_time;
       }
-//     }//==mlOdomEnc.end(), we cannot test ++iter
-  }else{//should==mlOdomEnc.begin()
-    while (iter!=mlOdomEnc.end()){//begin is min >= lastKFTime-err
-      if (iter->mtm>=cur_time) break;//get min >= lastKFTime+0
+    } else {  // we don't need to compare anything when iter->mtm>=cur_time
+      minErr = iter->mtm - cur_time;
+    }
+    //     }//==mlOdomEnc.end(), we cannot test ++iter
+  } else {                               // should==mlOdomEnc.begin()
+    while (iter != mlOdomEnc.end()) {    // begin is min >= lastKFTime-err
+      if (iter->mtm >= cur_time) break;  // get min >= lastKFTime+0
       ++iter;
     }
-    if (iter!=mlOdomEnc.end()){
-      minErr=iter->mtm-cur_time;
-      if (iter!=mlOdomEnc.begin()){
-        iter1=iter;--iter1;//iter-1
-        if (cur_time-iter1->mtm<minErr){
-          iter=iter1;
-          minErr=cur_time-iter1->mtm;
+    if (iter != mlOdomEnc.end()) {
+      minErr = iter->mtm - cur_time;
+      if (iter != mlOdomEnc.begin()) {
+        iter1 = iter;
+        --iter1;  // iter-1
+        if (cur_time - iter1->mtm < minErr) {
+          iter = iter1;
+          minErr = cur_time - iter1->mtm;
         }
       }
-    }else{//==mlOdomEnc.end(), but we can test --iter
-      //Notice mlOdomEnc.empty()==false!
+    } else {  //==mlOdomEnc.end(), but we can test --iter
+      // Notice mlOdomEnc.empty()==false!
       --iter;
-      minErr=cur_time-iter->mtm;
+      minErr = cur_time - iter->mtm;
     }
   }
-  if (minErr<=err_odomimg){//we found nearest allowed iterj/iteri to cur_time/lastKFTime
+  if (minErr <= err_odomimg) {  // we found nearest allowed iterj/iteri to cur_time/lastKFTime
     return true;
   }
-  return false;//if iteri/j is not in allowed err, returned iter points to nearest one to cur_time or end()
+  return false;  // if iteri/j is not in allowed err, returned iter points to nearest one to cur_time or end()
 }
-template<class OdomData>
+template <class OdomData>
 bool Tracking::PreIntegration(const int8_t type, Eigen::aligned_list<OdomData> &lodom_data,
-                              typename Eigen::aligned_list<OdomData>::const_iterator &iter_lastodom,
-                              FrameBase *plastfb, FrameBase *pcurfb, KeyFrame *plastkf, int8_t verbose) {
+                              typename Eigen::aligned_list<OdomData>::const_iterator &iter_lastodom, FrameBase *plastfb,
+                              FrameBase *pcurfb, KeyFrame *plastkf, FrameBase *plastfb_kf, bool breset_intkf,
+                              int8_t verbose) {
   using Eigen::aligned_list;
   using Tldata = OdomData;
 
   double cur_time = pcurfb->mTimeStamp;
   double derr_imuimg = mdErrIMUImg;
   bool ret = true;
-  switch (type){//0/2 will cull 2 Odom lists,1 will shift the pointer
-    case 0://for 0th keyframe/frame: erase all the data whose tm<=mCurrentFrame.mTimeStamp but keep the last one, like list.clear()
+  switch (type) {  // 0/2 will cull 2 Odom lists,1 will shift the pointer
+    case 0:  // for 0th keyframe/frame: erase all the data whose tm<=mCurrentFrame.mTimeStamp but keep the last one,
+             // like list.clear()
       if (!lodom_data.empty()) {
         typename aligned_list<Tldata>::const_iterator iter = lodom_data.end();
         // we just find the nearest iteri(for next time) to cur_time, don't need to judge if it's true
         iterijFind<OdomData>(lodom_data, cur_time, iter, derr_imuimg);
         if (verbose)
-          cout<<redSTR"ID="<<mCurrentFrame.mnId<<"; curDiff:"<<iter->mtm-cur_time<<whiteSTR<<endl;
+          cout << redSTR "ID=" << mCurrentFrame.mnId << "; curDiff:" << iter->mtm - cur_time << whiteSTR << endl;
 
         // retain the nearest allowed OdomData / iteri used to calculate the Enc PreIntegration
         lodom_data.erase(lodom_data.begin(), iter);
         // nearest iterj to cur_time(next time it may not be the nearest iteri to lastKFTime when
         // mlOdom.back().mtm<cur_time); maybe end() but we handle it in the CacheOdom()
         iter_lastodom = lodom_data.begin();
-     }
+      }
       break;
     case 1:
     case 3:  // only support Frame* pcurf here
@@ -399,10 +415,9 @@ bool Tracking::PreIntegration(const int8_t type, Eigen::aligned_list<OdomData> &
       // RecomputeIMUBiasAndCurrentNavstate()
       if (!lodom_data.empty()) {
         double last_time = plastfb->mTimeStamp;
-        bool bforce_reset = type == 3 && plastkf && plastkf != plastfb;
+        bool biteri_research = plastfb_kf && plastfb_kf->mTimeStamp != plastfb->mTimeStamp;
         typename aligned_list<Tldata>::const_iterator iter = lodom_data.end(), iterj,
-                                                      iteri = (type == 1 || bforce_reset) ? iter_lastodom
-                                                                                          : lodom_data.begin();
+                                                      iteri = type == 1 ? iter_lastodom : lodom_data.begin();
         // iterj&iteri both found then calculate delta~xij(phi,p)
         if (iterijFind<OdomData>(lodom_data, cur_time, iter, derr_imuimg) &&
             iterijFind<OdomData>(lodom_data, last_time, iteri, derr_imuimg, false)) {
@@ -414,16 +429,17 @@ bool Tracking::PreIntegration(const int8_t type, Eigen::aligned_list<OdomData> &
 
           // maybe if plastkf == plastfb, we could speed up/skip this preintegration here
           if (plastkf) {
+            assert(plastfb_kf);
             Frame *pcurf = dynamic_cast<Frame *>(pcurfb);
-            if (bforce_reset) {
-              last_time = plastkf->mTimeStamp;
+            if (biteri_research) {
+              last_time = plastfb_kf->mTimeStamp;
               iteri = lodom_data.begin();
               if (iterijFind<OdomData>(lodom_data, last_time, iteri, derr_imuimg, false))
-                ret = !pcurf->PreIntegrationFromLastKF<OdomData>((FrameBase *)plastkf, iteri, iterj, true);
+                ret = !pcurf->PreIntegrationFromLastKF<OdomData>(plastkf, plastfb_kf, iteri, iterj, breset_intkf);
               else
                 ret = false;
             } else
-              ret = !pcurf->PreIntegrationFromLastKF<OdomData>((FrameBase *)plastkf, iteri, iterj, plastkf == plastfb);
+              ret = !pcurf->PreIntegrationFromLastKF<OdomData>(plastkf, plastfb_kf, iteri, iterj, breset_intkf);
           }
         } else
           ret = false;
@@ -474,6 +490,6 @@ bool Tracking::PreIntegration(const int8_t type, Eigen::aligned_list<OdomData> &
   return ret;
 }
 
-} //namespace ORB_SLAM
+}  // namespace VIEO_SLAM
 
-#endif // TRACKING_H
+#endif  // TRACKING_H

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -76,15 +76,15 @@ void Frame::DeepMovePreintOdomFromLastKF(IMUPreintegrator &preint_odom) {
   preint_odom.AppendFrontPreIntegrationList(lodom, lodom.begin(), lodom.end());
 }
 template <>
-int Frame::PreIntegrationFromLastKF<IMUData>(FrameBase *plastkf, const typename aligned_list<IMUData>::const_iterator &iteri,
+int Frame::PreIntegrationFromLastKF<IMUData>(FrameBase *plastkf, FrameBase *plastfb_kf, const typename aligned_list<IMUData>::const_iterator &iteri,
                               const typename aligned_list<IMUData>::const_iterator &iterj, bool breset,
                               int8_t verbose) {
   CV_Assert(ppreint_imu_kf_);
   NavState ns = plastkf->GetNavState();
   auto iterj_1 = iterj;
   --iterj_1;
-  return FrameBase::PreIntegration<IMUData>(breset ? plastkf->mTimeStamp : (*iteri).mtm, (*iterj_1).mtm, ns.mbg, ns.mba,
-                                            iteri, iterj, breset, ppreint_imu_kf_, verbose);
+  return FrameBase::PreIntegration<IMUData>(breset ? plastfb_kf->mTimeStamp : (*iteri).mtm, (*iterj_1).mtm, ns.mbg,
+                                            ns.mba, iteri, iterj, breset, ppreint_imu_kf_, verbose);
 }
 //zzh
 


### PR DESCRIPTION
    1.fix kf2kf average bug when new kf created
    before lba update map and when gba update map
    and when type==3 but plastfb_kf->tm!=plastkf->tm
    2.notice plastkf's bgba won't be changed during
    kf->newest kf
    3.format Tracking.h

TEST: passed on datasets, though accuracy almost unchanged, the logic now is perfect